### PR TITLE
Fix loading the integration with HACS

### DIFF
--- a/custom_components/terramow/manifest.json
+++ b/custom_components/terramow/manifest.json
@@ -8,6 +8,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/TerraMow/TerraMowHA",
+  "issue_tracker": "https://github.com/TerraMow/TerraMowHA/issues",
   "iot_class": "local_push",
   "requirements": ["paho-mqtt>=1.6.1"],
   "version": "0.1.1"

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,3 @@
 {
-  "name": "TerramowHA",
-  "content_in_root": false,
+  "name": "TerramowHA"
 }


### PR DESCRIPTION
I found that HACS wouldn't load from the repository as-is.  _issue_tracker_ is a required parameter in the manifest.json, and it wasn't happy with the trailing comma and the _content_in_root_ tag in the hacs.json.

Tested against latest HACS by adding my repo to HACS and downloading the integration.