### PR TITLE
[03/13] Add error state, back-to-station-reason and rain detection sensors

### DIFF
--- a/custom_components/terramow/binary_sensor.py
+++ b/custom_components/terramow/binary_sensor.py
@@ -27,6 +27,8 @@ async def async_setup_entry(
 
     entities = [
         TerraMowChargingSensor(basic_data, hass),
+        TerraMowProblemSensor(basic_data, hass),
+        TerraMowRainSensor(basic_data, hass),
     ]
 
     async_add_entities(entities)
@@ -78,6 +80,99 @@ class TerraMowChargingSensor(BinarySensorEntity):
         charger_connected = battery_status.get('charger_connected')
 
         return bool(charger_connected) if charger_connected is not None else None
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.basic_data.lawn_mower is not None
+
+
+class TerraMowProblemSensor(BinarySensorEntity):
+    """Binary sensor exposing the dp_107 has_error flag as a problem."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "problem"
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = self.basic_data.host
+        self.hass = hass
+        _LOGGER.info("TerraMowProblemSensor entity created")
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model
+        )
+
+    @property
+    def unique_id(self):
+        """Return a unique ID for this entity."""
+        return f"lawn_mower.terramow@{self.host}.problem"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the robot reports an error."""
+        if not hasattr(self.basic_data, 'lawn_mower') or not self.basic_data.lawn_mower:
+            return None
+        return bool(self.basic_data.lawn_mower.has_error)
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.basic_data.lawn_mower is not None
+
+
+class TerraMowRainSensor(BinarySensorEntity):
+    """Binary sensor that signals when the robot returns due to rain."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "rain_detected"
+    _attr_device_class = BinarySensorDeviceClass.MOISTURE
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = self.basic_data.host
+        self.hass = hass
+        _LOGGER.info("TerraMowRainSensor entity created")
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model
+        )
+
+    @property
+    def unique_id(self):
+        """Return a unique ID for this entity."""
+        return f"lawn_mower.terramow@{self.host}.rain_detected"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the back-to-station reason is raining."""
+        if not hasattr(self.basic_data, 'lawn_mower') or not self.basic_data.lawn_mower:
+            return None
+        return self.basic_data.lawn_mower.back_to_station_reason == "BACK_TO_STATION_REASON_RAINING"
 
     @property
     def available(self):

--- a/custom_components/terramow/lawn_mower.py
+++ b/custom_components/terramow/lawn_mower.py
@@ -181,6 +181,7 @@ class TerraMowLawnMowerEntity(LawnMowerEntity):
         self._blade_time: dict[str, Any] = {}  # 存储dp_126刀盘使用时间
         self._schedule_data: dict[str, Any] = {}  # 存储dp_138即将到来的预约
         self._battery_status: dict[str, Any] = {} # Store dp_108 battery status
+        self._task_status: dict[str, Any] = {}  # Store dp_107 task status raw payload
         self._device_model: str = "TerraMow S1200"  # 默认型号名称，保持向后兼容
         self.basic_data.lawn_mower = self
 
@@ -188,7 +189,6 @@ class TerraMowLawnMowerEntity(LawnMowerEntity):
         self.mission = Mission.MISSION_IDLE
         self.sub_mission = SubMission.SUB_MISSION_IDLE
         self.mission_state = MissionState.MISSION_STATE_IDLE
-        self.has_error = False
 
         self.cmd_seq = random.randint(0, 0xFFFFFFFF)  # 生成随机的指令序号
 
@@ -461,6 +461,10 @@ class TerraMowLawnMowerEntity(LawnMowerEntity):
             _LOGGER.error("Invalid JSON payload: %s", payload)
             return
 
+        # Preserve the raw payload so that downstream entities can read fields
+        # like has_error / back_to_station_reason without enum conversion.
+        self._task_status = dict(data)
+
         # Define a mapping from field names to enum classes
         enum_mapping = {
             "mission": Mission,
@@ -485,16 +489,14 @@ class TerraMowLawnMowerEntity(LawnMowerEntity):
         old_mission = self.mission
         old_sub_mission = self.sub_mission
         old_mission_state = self.mission_state
-        old_has_error = self.has_error
 
         self.mission = data.get("mission", self.mission)
         self.sub_mission = data.get("sub_mission", self.sub_mission)
         self.mission_state = data.get("state", self.mission_state)
-        self.has_error = data.get("has_error", self.has_error)
 
-        _LOGGER.debug("Mission state updated: mission=%s->%s, sub_mission=%s->%s, state=%s->%s, error=%s->%s",
+        _LOGGER.debug("Mission state updated: mission=%s->%s, sub_mission=%s->%s, state=%s->%s, has_error=%s, back_to_station_reason=%s",
                      old_mission, self.mission, old_sub_mission, self.sub_mission,
-                     old_mission_state, self.mission_state, old_has_error, self.has_error)
+                     old_mission_state, self.mission_state, self.has_error, self.back_to_station_reason)
 
         self.update_activity_from_state()
 
@@ -1176,6 +1178,21 @@ class TerraMowLawnMowerEntity(LawnMowerEntity):
     def battery_status(self) -> dict:
         """Get current battery status from dp_108."""
         return self._battery_status
+
+    @property
+    def task_status(self) -> dict:
+        """Get current task status raw payload from dp_107."""
+        return self._task_status
+
+    @property
+    def has_error(self) -> bool:
+        """Return whether the robot currently reports a fault (dp_107)."""
+        return bool(self._task_status.get("has_error", False))
+
+    @property
+    def back_to_station_reason(self) -> str | None:
+        """Return the raw back_to_station_reason enum string from dp_107."""
+        return self._task_status.get("back_to_station_reason")
 
     @property
     def compatibility_status(self) -> str:

--- a/custom_components/terramow/sensor.py
+++ b/custom_components/terramow/sensor.py
@@ -849,8 +849,11 @@ async def async_setup_entry(
         
         # 主方向状态传感器
         MainDirectionStatusSensor(basic_data, hass),
+
+        # 任务状态相关 (dp_107)
+        BackToStationReasonSensor(basic_data, hass),
     ]
-    
+
     async_add_entities(entities)
 
 
@@ -958,6 +961,66 @@ class MainDirectionStatusSensor(SensorEntity):
             'MAIN_DIRECTION_MODE_AUTO_ROTATE': 'Auto Rotate'
         }
         attrs['mode_friendly_name'] = mode_names.get(mode, mode)
-        
+
         return attrs
-    
+
+
+BACK_TO_STATION_REASON_OPTIONS = [
+    "BACK_TO_STATION_REASON_NONE",
+    "BACK_TO_STATION_REASON_LOW_BATTERY",
+    "BACK_TO_STATION_REASON_RAINING",
+    "BACK_TO_STATION_REASON_MOW_MOTOR_OVERHEAT",
+    "BACK_TO_STATION_REASON_WHEEL_OVERHEAT",
+    "BACK_TO_STATION_REASON_NIGHT_TIME",
+]
+
+
+class BackToStationReasonSensor(SensorEntity):
+    """Enum sensor exposing the dp_107 back_to_station_reason field."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:home-import-outline"
+    _attr_translation_key = "back_to_station_reason"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = BACK_TO_STATION_REASON_OPTIONS.copy()
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = basic_data.host
+        self.hass = hass
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model
+        )
+
+    @property
+    def unique_id(self):
+        """Return a unique ID for this entity."""
+        return f"lawn_mower.terramow@{self.host}.back_to_station_reason"
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the raw back_to_station_reason enum string."""
+        if not hasattr(self.basic_data, 'lawn_mower') or not self.basic_data.lawn_mower:
+            return None
+        reason = self.basic_data.lawn_mower.back_to_station_reason
+        if reason in self._attr_options:
+            return reason
+        return None
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.basic_data.lawn_mower is not None

--- a/custom_components/terramow/translations/de.json
+++ b/custom_components/terramow/translations/de.json
@@ -100,6 +100,17 @@
                     "unavailable": "Nicht verfügbar",
                     "no_config": "Keine Konfiguration"
                 }
+            },
+            "back_to_station_reason": {
+                "name": "Grund für Rückkehr zur Basis",
+                "state": {
+                    "BACK_TO_STATION_REASON_NONE": "Keiner",
+                    "BACK_TO_STATION_REASON_LOW_BATTERY": "Niedriger Akkustand",
+                    "BACK_TO_STATION_REASON_RAINING": "Regen",
+                    "BACK_TO_STATION_REASON_MOW_MOTOR_OVERHEAT": "Mähmotor überhitzt",
+                    "BACK_TO_STATION_REASON_WHEEL_OVERHEAT": "Antriebsmotor überhitzt",
+                    "BACK_TO_STATION_REASON_NIGHT_TIME": "Dunkelheit"
+                }
             }
         },
         "camera": {
@@ -110,6 +121,12 @@
         "binary_sensor": {
             "charging_state": {
                 "name": "Ladestatus"
+            },
+            "problem": {
+                "name": "Problem"
+            },
+            "rain_detected": {
+                "name": "Regen erkannt"
             }
         },
         "select": {

--- a/custom_components/terramow/translations/en.json
+++ b/custom_components/terramow/translations/en.json
@@ -100,6 +100,17 @@
                     "unavailable": "Unavailable",
                     "no_config": "No Configuration"
                 }
+            },
+            "back_to_station_reason": {
+                "name": "Back to Station Reason",
+                "state": {
+                    "BACK_TO_STATION_REASON_NONE": "None",
+                    "BACK_TO_STATION_REASON_LOW_BATTERY": "Low Battery",
+                    "BACK_TO_STATION_REASON_RAINING": "Raining",
+                    "BACK_TO_STATION_REASON_MOW_MOTOR_OVERHEAT": "Mowing Motor Overheating",
+                    "BACK_TO_STATION_REASON_WHEEL_OVERHEAT": "Drive Wheel Overheating",
+                    "BACK_TO_STATION_REASON_NIGHT_TIME": "Darkness"
+                }
             }
         },
         "camera": {
@@ -110,6 +121,12 @@
         "binary_sensor": {
             "charging_state": {
                 "name": "Charging State"
+            },
+            "problem": {
+                "name": "Problem"
+            },
+            "rain_detected": {
+                "name": "Rain Detected"
             }
         },
         "select": {

--- a/custom_components/terramow/translations/zh-Hans.json
+++ b/custom_components/terramow/translations/zh-Hans.json
@@ -100,6 +100,17 @@
                     "unavailable": "不可用",
                     "no_config": "无配置"
                 }
+            },
+            "back_to_station_reason": {
+                "name": "回基站原因",
+                "state": {
+                    "BACK_TO_STATION_REASON_NONE": "无",
+                    "BACK_TO_STATION_REASON_LOW_BATTERY": "电量不足",
+                    "BACK_TO_STATION_REASON_RAINING": "下雨",
+                    "BACK_TO_STATION_REASON_MOW_MOTOR_OVERHEAT": "刀盘电机过热",
+                    "BACK_TO_STATION_REASON_WHEEL_OVERHEAT": "驱动轮电机过热",
+                    "BACK_TO_STATION_REASON_NIGHT_TIME": "夜间"
+                }
             }
         },
         "camera": {
@@ -110,6 +121,12 @@
         "binary_sensor": {
             "charging_state": {
                 "name": "充电状态"
+            },
+            "problem": {
+                "name": "故障"
+            },
+            "rain_detected": {
+                "name": "检测到降雨"
             }
         },
         "select": {


### PR DESCRIPTION
## Merge order
**Position:** 03 of 13
**Depends on:** #41, #42
**Blocks:** #44, #45, #46 (all touch `binary_sensor.py` and `sensor.py`)
**File conflicts with:** #44, #45, #46

## What this changes
Three new entities derived from `dp_107`:
- `binary_sensor.terramow_problem` (`device_class: problem`) — based on `has_error`
- `sensor.terramow_back_to_station_reason` (enum, 6 values) — diagnostic
- `binary_sensor.terramow_rain_detected` (`device_class: moisture`) — derived sensor that short-circuits `back_to_station_reason == BACK_TO_STATION_REASON_RAINING` for automation convenience

## Data points / protocol references
- `dp_107` (Task Status), fields `has_error`, `back_to_station_reason`
- Enum values listed in `docs/en/developers/data_point.md` → "Task Status"

## Validation
- [ ] `python -m compileall custom_components/terramow` clean
- [ ] Tested against TerraMow firmware <X.Y.Z>
- [ ] Translations updated: en, de, zh-CN, zh-Hans

## Open questions for maintainer
- `rain_detected` is intentionally a derived/convenience entity rather than just relying on a template sensor in the user's automation. OK to ship it as a first-class entity, or prefer to keep only the raw enum sensor?