### PR TITLE
[01/13] Modernize manifest, bump minimum HA version, add quality_scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following parameters are required:
 
 ### Requirements
 
-- Home Assistant 2023.9.3 or later (tested with 2025.1.1)
+- Home Assistant 2024.4 or later (tested with 2025.1.1)
 - TerraMow firmware version 6.6.0 or later
 - TerraMow APP version 1.6.0 or later
 

--- a/custom_components/terramow/manifest.json
+++ b/custom_components/terramow/manifest.json
@@ -8,9 +8,11 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/TerraMow/TerraMowHA",
-  "issue_tracker": "https://github.com/TerraMow/TerraMowHA/issues",
+  "integration_type": "device",
   "iot_class": "local_push",
+  "issue_tracker": "https://github.com/TerraMow/TerraMowHA/issues",
+  "loggers": ["paho.mqtt"],
+  "quality_scale": "bronze",
   "requirements": ["paho-mqtt>=1.6.1", "Pillow>=9.0.0"],
-  "version": "0.3.0",
-  "homeassistant": "2023.9.3"
+  "version": "0.4.0"
 }


### PR DESCRIPTION
## Merge order
**Position:** 01 of 13
**Depends on:** — (foundation)
**Blocks:** all 12 subsequent PRs will need a rebase after this lands
**File conflicts with:** #52 (manifest.json — zeroconf block added there)

## What this changes
Removes the outdated `homeassistant: 2023.9.3` pin, adds `integration_type: device`, `quality_scale`, `loggers`, and bumps the version. Updates `README.md` to reflect the new minimum Home Assistant version. No runtime behaviour change.

## Data points / protocol references
None — configuration / metadata only.

## Validation
- [ ] `python -m compileall custom_components/terramow` clean
- [ ] `manifest.json` is valid JSON
- [ ] `hacs.json` still parses

## Open questions for maintainer
- Version bump target: current upstream is `v0.2.5`. Suggesting `v0.4.0` because this batch raises the minimum HA version (potentially breaking for installs on old HA versions). OK to bump to `0.4.0` directly, or prefer `0.3.0`?