### PR TITLE
[02/13] Add GitHub Actions for hassfest, HACS validation and Python lint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+---
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+      - "[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.3.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve tag and version
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify manifest version matches tag
+        env:
+          TAG_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          MANIFEST_PATH=custom_components/terramow/manifest.json
+          MANIFEST_VERSION=$(python -c \
+            "import json,sys; print(json.load(open(sys.argv[1]))['version'])" \
+            "$MANIFEST_PATH")
+          echo "manifest version: ${MANIFEST_VERSION}"
+          echo "tag version:      ${TAG_VERSION}"
+          if [ "${MANIFEST_VERSION}" != "${TAG_VERSION}" ]; then
+            echo "::error::manifest.json version (${MANIFEST_VERSION}) does not match tag (${TAG_VERSION})"
+            exit 1
+          fi
+
+      - name: Create HACS-compatible zip
+        run: |
+          cd custom_components/terramow
+          zip -r "${{ github.workspace }}/terramow.zip" .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.tag }}
+          generate_release_notes: true
+          files: |
+            terramow.zip

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,57 @@
+---
+name: Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"
+
+jobs:
+  hassfest:
+    name: Hassfest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run hassfest
+        uses: home-assistant/actions/hassfest@master
+
+  hacs:
+    name: HACS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration
+
+  python-lint:
+    name: Python Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Compile Python sources
+        run: python -m compileall custom_components/terramow
+
+      - name: Install ruff
+        run: python -m pip install --upgrade pip ruff
+
+      - name: Run ruff
+        continue-on-error: true
+        run: ruff check custom_components/terramow

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,13 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 140
+    level: warning
+  truthy:
+    check-keys: false
+  comments:
+    min-spaces-from-content: 1
+  document-start:
+    present: true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
     <a href="#english-version"><img src="https://img.shields.io/badge/English-blue?style=for-the-badge" alt="English"/></a>
     <a href="docs/README_zh.md"><img src="https://img.shields.io/badge/中文-red?style=for-the-badge" alt="中文"/></a>
   </p>
+  <p>
+    <a href="https://github.com/TerraMow/TerraMowHA/actions/workflows/validate.yml"><img src="https://github.com/TerraMow/TerraMowHA/actions/workflows/validate.yml/badge.svg" alt="Validate"/></a>
+    <a href="https://github.com/TerraMow/TerraMowHA/actions/workflows/release.yml"><img src="https://github.com/TerraMow/TerraMowHA/actions/workflows/release.yml/badge.svg" alt="Release"/></a>
+  </p>
   <img src="docs/images/terramow_logo.png" alt="TerraMow Logo" width="400">
 </div>
 


### PR DESCRIPTION
## Merge order
**Position:** 02 of 13
**Depends on:** #41
**Blocks:** none directly — but landing this early gives every subsequent PR a CI signal
**File conflicts with:** none (only new files)

## What this changes
Adds `.github/workflows/validate.yml` running `hassfest`, `hacs/action`, and `python -m compileall`. Adds `release.yml` for tag-based releases. Adds CI badges to `README.md`.

## Data points / protocol references
None.

## Validation
- [ ] Green CI run on this PR itself
- [ ] HACS action passes against `hacs.json`
- [ ] hassfest passes against the (modernized) `manifest.json`

## Open questions for maintainer
- `ruff` is included in `continue-on-error: true` mode initially. Intentional — once existing code is gradually cleaned up, the flag can be removed. Acceptable approach?