### PR TITLE
[04/13] Add buttons to reset blade disk and base station maintenance counters

### DIFF
--- a/custom_components/terramow/__init__.py
+++ b/custom_components/terramow/__init__.py
@@ -24,7 +24,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.LAWN_MOWER, Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SELECT, Platform.NUMBER, Platform.CAMERA]
+PLATFORMS: list[Platform] = [Platform.LAWN_MOWER, Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SELECT, Platform.NUMBER, Platform.CAMERA, Platform.BUTTON]
 
 @dataclass
 class TerraMowBasicData:

--- a/custom_components/terramow/button.py
+++ b/custom_components/terramow/button.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import TerraMowBasicData, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the TerraMow button entities."""
+    basic_data = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities = [
+        ResetBladeTimerButton(basic_data, hass),
+        ResetBaseStationTimerButton(basic_data, hass),
+    ]
+
+    async_add_entities(entities)
+
+
+class TerraMowResetButtonBase(ButtonEntity):
+    """Base class for TerraMow reset buttons."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = self.basic_data.host
+        self.hass = hass
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.basic_data.lawn_mower is not None
+
+
+class ResetBladeTimerButton(TerraMowResetButtonBase):
+    """Button to reset the mowing blade disk usage time."""
+
+    _attr_translation_key = "reset_blade_timer"
+    _attr_icon = "mdi:saw-blade"
+
+    @property
+    def unique_id(self) -> str:
+        return f"lawn_mower.terramow@{self.host}.reset_blade_timer"
+
+    async def async_press(self) -> None:
+        """Reset the blade timer by sending 0 to dp_126."""
+        _LOGGER.info("Resetting blade timer")
+        self.basic_data.lawn_mower.publish_data_point(126, {"int_value": 0})
+
+
+class ResetBaseStationTimerButton(TerraMowResetButtonBase):
+    """Button to reset the base station usage time."""
+
+    _attr_translation_key = "reset_base_station_timer"
+    _attr_icon = "mdi:home-lightning-bolt"
+
+    @property
+    def unique_id(self) -> str:
+        return f"lawn_mower.terramow@{self.host}.reset_base_station_timer"
+
+    async def async_press(self) -> None:
+        """Reset the base station timer by sending 0 to dp_125."""
+        _LOGGER.info("Resetting base station timer")
+        self.basic_data.lawn_mower.publish_data_point(125, {"int_value": 0})

--- a/custom_components/terramow/translations/de.json
+++ b/custom_components/terramow/translations/de.json
@@ -112,6 +112,14 @@
                 "name": "Ladestatus"
             }
         },
+        "button": {
+            "reset_blade_timer": {
+                "name": "Klingen-Zähler zurücksetzen"
+            },
+            "reset_base_station_timer": {
+                "name": "Basisstation-Zähler zurücksetzen"
+            }
+        },
         "select": {
             "region_select": {
                 "name": "Zonenauswahl"

--- a/custom_components/terramow/translations/en.json
+++ b/custom_components/terramow/translations/en.json
@@ -112,6 +112,14 @@
                 "name": "Charging State"
             }
         },
+        "button": {
+            "reset_blade_timer": {
+                "name": "Reset Blade Timer"
+            },
+            "reset_base_station_timer": {
+                "name": "Reset Base Station Timer"
+            }
+        },
         "select": {
             "region_select": {
                 "name": "Zone Select"

--- a/custom_components/terramow/translations/zh-Hans.json
+++ b/custom_components/terramow/translations/zh-Hans.json
@@ -112,6 +112,14 @@
                 "name": "充电状态"
             }
         },
+        "button": {
+            "reset_blade_timer": {
+                "name": "重置刀盘计时"
+            },
+            "reset_base_station_timer": {
+                "name": "重置基站计时"
+            }
+        },
         "select": {
             "region_select": {
                 "name": "分区选择"


### PR DESCRIPTION
## Merge order
**Position:** 04 of 13
**Depends on:** #41, #42
**Blocks:** #47 (also writes to `button.py`)
**File conflicts with:** #47

## What this changes
New `button` platform. Two buttons that publish `{"int_value": 0}` to `dp_125` (base station usage time) and `dp_126` (mowing blade disk usage time) to reset their respective maintenance counters.

## Data points / protocol references
- `dp_125`, `dp_126`. Doc: *"When the robot receives a value of 0, it will reset the internal record of usage time to 0."*

## Validation
- [ ] `python -m compileall custom_components/terramow` clean
- [ ] Manually pressed both buttons against firmware <X.Y.Z> and verified counters reset
- [ ] Translations updated: en, de, zh-CN, zh-Hans

## Open questions for maintainer
- Buttons use HA's standard press semantics — no double-confirm modal. Acceptable for these destructive actions, or should the integration add a confirmation prompt?