### PR TITLE
[05/13] Expose battery temperature, state and power switch as sensors

### DIFF
--- a/custom_components/terramow/binary_sensor.py
+++ b/custom_components/terramow/binary_sensor.py
@@ -27,6 +27,7 @@ async def async_setup_entry(
 
     entities = [
         TerraMowChargingSensor(basic_data, hass),
+        PowerSwitchSensor(basic_data, hass),
     ]
 
     async_add_entities(entities)
@@ -78,6 +79,57 @@ class TerraMowChargingSensor(BinarySensorEntity):
         charger_connected = battery_status.get('charger_connected')
 
         return bool(charger_connected) if charger_connected is not None else None
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.basic_data.lawn_mower is not None
+
+
+class PowerSwitchSensor(BinarySensorEntity):
+    """Binary sensor for the TerraMow power switch state."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "power_switch"
+    _attr_device_class = BinarySensorDeviceClass.POWER
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        """Initialize the power switch sensor."""
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = self.basic_data.host
+        self.hass = hass
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model
+        )
+
+    @property
+    def unique_id(self):
+        """Return a unique ID for this entity."""
+        return f"lawn_mower.terramow@{self.host}.power_switch"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the binary sensor is on."""
+        if not hasattr(self.basic_data, 'lawn_mower') or not self.basic_data.lawn_mower:
+            return None
+
+        battery_status = self.basic_data.lawn_mower.battery_status
+        is_switch_on = battery_status.get('is_switch_on')
+
+        return bool(is_switch_on) if is_switch_on is not None else None
 
     @property
     def available(self):

--- a/custom_components/terramow/sensor.py
+++ b/custom_components/terramow/sensor.py
@@ -128,6 +128,117 @@ class BatterySensor(SensorEntity):
         }
 
 
+class BatteryStateSensor(SensorEntity):
+    """Battery state sensor - uses dp_108 data."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:battery-charging"
+    _attr_translation_key = "battery_state"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = [
+        "BATTERY_STATE_DISCHARGE",
+        "BATTERY_STATE_CHARGING",
+        "BATTERY_STATE_CHARGED",
+    ]
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = basic_data.host
+        self.hass = hass
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model
+        )
+
+    @property
+    def unique_id(self):
+        """Return a unique ID for this entity."""
+        return f"lawn_mower.terramow@{self.host}.battery_state"
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the state of the sensor."""
+        if not hasattr(self.basic_data, 'lawn_mower') or not self.basic_data.lawn_mower:
+            return None
+
+        battery_status = self.basic_data.lawn_mower.battery_status
+        if not battery_status:
+            return None
+
+        state = battery_status.get('state')
+        if state in self._attr_options:
+            return state
+        return None
+
+
+class BatteryTemperatureStateSensor(SensorEntity):
+    """Battery temperature state sensor - uses dp_108 data."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:thermometer"
+    _attr_translation_key = "battery_temperature_state"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = [
+        "BATTERY_TEMPRETURE_NORMAL",
+        "BATTERY_TEMPRETURE_OVERHEAT",
+        "BATTERY_TEMPRETURE_UNDERHEAT",
+    ]
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = basic_data.host
+        self.hass = hass
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model
+        )
+
+    @property
+    def unique_id(self):
+        """Return a unique ID for this entity."""
+        return f"lawn_mower.terramow@{self.host}.battery_temperature_state"
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the state of the sensor."""
+        if not hasattr(self.basic_data, 'lawn_mower') or not self.basic_data.lawn_mower:
+            return None
+
+        battery_status = self.basic_data.lawn_mower.battery_status
+        if not battery_status:
+            return None
+
+        # Firmware reports the field as 'tempreture' (typo preserved).
+        value = battery_status.get('tempreture')
+        if value in self._attr_options:
+            return value
+        return None
+
+
 class TotalMowingTimeSensor(SensorEntity):
     """Total mowing time sensor - uses dp_124 data"""
     
@@ -821,6 +932,8 @@ async def async_setup_entry(
     entities = [
         # 基本传感器
         BatterySensor(basic_data, hass),
+        BatteryStateSensor(basic_data, hass),
+        BatteryTemperatureStateSensor(basic_data, hass),
         TerraMowPoseSensor(basic_data, hass),
         
         # 地图相关传感器

--- a/custom_components/terramow/translations/de.json
+++ b/custom_components/terramow/translations/de.json
@@ -28,6 +28,22 @@
             "battery": {
                 "name": "Akku"
             },
+            "battery_state": {
+                "name": "Akkustatus",
+                "state": {
+                    "BATTERY_STATE_DISCHARGE": "Entlädt",
+                    "BATTERY_STATE_CHARGING": "Lädt",
+                    "BATTERY_STATE_CHARGED": "Vollständig geladen"
+                }
+            },
+            "battery_temperature_state": {
+                "name": "Akkutemperaturstatus",
+                "state": {
+                    "BATTERY_TEMPRETURE_NORMAL": "Normal",
+                    "BATTERY_TEMPRETURE_OVERHEAT": "Überhitzt",
+                    "BATTERY_TEMPRETURE_UNDERHEAT": "Unterkühlt"
+                }
+            },
             "map_status": {
                 "name": "Kartenstatus",
                 "state": {
@@ -110,6 +126,9 @@
         "binary_sensor": {
             "charging_state": {
                 "name": "Ladestatus"
+            },
+            "power_switch": {
+                "name": "Netzschalter"
             }
         },
         "select": {

--- a/custom_components/terramow/translations/en.json
+++ b/custom_components/terramow/translations/en.json
@@ -28,6 +28,22 @@
             "battery": {
                 "name": "Battery"
             },
+            "battery_state": {
+                "name": "Battery State",
+                "state": {
+                    "BATTERY_STATE_DISCHARGE": "Discharging",
+                    "BATTERY_STATE_CHARGING": "Charging",
+                    "BATTERY_STATE_CHARGED": "Fully Charged"
+                }
+            },
+            "battery_temperature_state": {
+                "name": "Battery Temperature State",
+                "state": {
+                    "BATTERY_TEMPRETURE_NORMAL": "Normal",
+                    "BATTERY_TEMPRETURE_OVERHEAT": "Overheat",
+                    "BATTERY_TEMPRETURE_UNDERHEAT": "Underheat"
+                }
+            },
             "map_status": {
                 "name": "Map Status",
                 "state": {
@@ -110,6 +126,9 @@
         "binary_sensor": {
             "charging_state": {
                 "name": "Charging State"
+            },
+            "power_switch": {
+                "name": "Power Switch"
             }
         },
         "select": {

--- a/custom_components/terramow/translations/zh-Hans.json
+++ b/custom_components/terramow/translations/zh-Hans.json
@@ -28,6 +28,22 @@
             "battery": {
                 "name": "电池"
             },
+            "battery_state": {
+                "name": "电池状态",
+                "state": {
+                    "BATTERY_STATE_DISCHARGE": "放电中",
+                    "BATTERY_STATE_CHARGING": "充电中",
+                    "BATTERY_STATE_CHARGED": "已充满"
+                }
+            },
+            "battery_temperature_state": {
+                "name": "电池温度状态",
+                "state": {
+                    "BATTERY_TEMPRETURE_NORMAL": "正常",
+                    "BATTERY_TEMPRETURE_OVERHEAT": "过热",
+                    "BATTERY_TEMPRETURE_UNDERHEAT": "过冷"
+                }
+            },
             "map_status": {
                 "name": "地图状态",
                 "state": {
@@ -110,6 +126,9 @@
         "binary_sensor": {
             "charging_state": {
                 "name": "充电状态"
+            },
+            "power_switch": {
+                "name": "电源开关"
             }
         },
         "select": {


### PR DESCRIPTION
## Merge order
**Position:** 05 of 13
**Depends on:** #41, #42, #40 (`binary_sensor.py` / `sensor.py` rebase)
**Blocks:** #45, #46
**File conflicts with:** #45, #46

## What this changes
Three diagnostic entities from `dp_108`:
- `sensor.terramow_battery_state` (enum: DISCHARGE / CHARGING / CHARGED)
- `sensor.terramow_battery_temperature_state` (enum: NORMAL / OVERHEAT / UNDERHEAT)
- `binary_sensor.terramow_power_switch` (`device_class: power`)

## Data points / protocol references
- `dp_108` (Battery Status), fields `state`, `tempreture` (sic — firmware typo preserved on the JSON read side), `is_switch_on`

## Validation
- [ ] `python -m compileall custom_components/terramow` clean
- [ ] Tested against firmware <X.Y.Z>
- [ ] Translations updated: en, de, zh-CN, zh-Hans

## Open questions for maintainer
- The firmware emits the field as `tempreture` (typo). On the reading side I match the firmware spelling; the entity is named `temperature_state`. Flagging so reviewers don't think the typo is in our code — let me know if a normalization layer is preferred.