### PR TITLE
[06/13] Add navigation, firmware-upgrade and power-mode diagnostic sensors

### DIFF
--- a/custom_components/terramow/binary_sensor.py
+++ b/custom_components/terramow/binary_sensor.py
@@ -27,6 +27,8 @@ async def async_setup_entry(
 
     entities = [
         TerraMowChargingSensor(basic_data, hass),
+        NavigationLocatedSensor(basic_data, hass),
+        FirmwareUpgradingSensor(basic_data, hass),
     ]
 
     async_add_entities(entities)
@@ -78,6 +80,102 @@ class TerraMowChargingSensor(BinarySensorEntity):
         charger_connected = battery_status.get('charger_connected')
 
         return bool(charger_connected) if charger_connected is not None else None
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.basic_data.lawn_mower is not None
+
+
+class NavigationLocatedSensor(BinarySensorEntity):
+    """Binary sensor for whether the robot is navigation-located."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "navigation_located"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:crosshairs-gps"
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = self.basic_data.host
+        self.hass = hass
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model
+        )
+
+    @property
+    def unique_id(self):
+        """Return a unique ID for this entity."""
+        return f"lawn_mower.terramow@{self.host}.navigation_located"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the robot is navigation-located."""
+        if not hasattr(self.basic_data, 'lawn_mower') or not self.basic_data.lawn_mower:
+            return None
+
+        value = self.basic_data.lawn_mower.is_robot_navi_located
+        return bool(value) if value is not None else None
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.basic_data.lawn_mower is not None
+
+
+class FirmwareUpgradingSensor(BinarySensorEntity):
+    """Binary sensor for whether the robot firmware is upgrading."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.UPDATE
+    _attr_translation_key = "firmware_upgrading"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = self.basic_data.host
+        self.hass = hass
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model
+        )
+
+    @property
+    def unique_id(self):
+        """Return a unique ID for this entity."""
+        return f"lawn_mower.terramow@{self.host}.firmware_upgrading"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the firmware is upgrading."""
+        if not hasattr(self.basic_data, 'lawn_mower') or not self.basic_data.lawn_mower:
+            return None
+
+        value = self.basic_data.lawn_mower.is_upgrading
+        return bool(value) if value is not None else None
 
     @property
     def available(self):

--- a/custom_components/terramow/lawn_mower.py
+++ b/custom_components/terramow/lawn_mower.py
@@ -189,6 +189,9 @@ class TerraMowLawnMowerEntity(LawnMowerEntity):
         self.sub_mission = SubMission.SUB_MISSION_IDLE
         self.mission_state = MissionState.MISSION_STATE_IDLE
         self.has_error = False
+        self._is_robot_navi_located: bool | None = None
+        self._is_upgrading: bool | None = None
+        self._power_mode: str | None = None
 
         self.cmd_seq = random.randint(0, 0xFFFFFFFF)  # 生成随机的指令序号
 
@@ -469,6 +472,14 @@ class TerraMowLawnMowerEntity(LawnMowerEntity):
             "power_mode": PowerMode,
             "back_to_station_reason": BackToStationReason
         }
+
+        # Capture raw fields before enum conversion mutates the dict
+        if "is_robot_navi_located" in data:
+            self._is_robot_navi_located = data.get("is_robot_navi_located")
+        if "is_upgrading" in data:
+            self._is_upgrading = data.get("is_upgrading")
+        if "power_mode" in data:
+            self._power_mode = data.get("power_mode")
 
         # Convert enum strings to enum members
         for key, enum_class in enum_mapping.items():
@@ -1176,6 +1187,21 @@ class TerraMowLawnMowerEntity(LawnMowerEntity):
     def battery_status(self) -> dict:
         """Get current battery status from dp_108."""
         return self._battery_status
+
+    @property
+    def is_robot_navi_located(self) -> bool | None:
+        """Get whether the robot is navigation-located (from dp_107)."""
+        return self._is_robot_navi_located
+
+    @property
+    def is_upgrading(self) -> bool | None:
+        """Get whether the robot is upgrading firmware (from dp_107)."""
+        return self._is_upgrading
+
+    @property
+    def power_mode(self) -> str | None:
+        """Get current power mode from dp_107."""
+        return self._power_mode
 
     @property
     def compatibility_status(self) -> str:

--- a/custom_components/terramow/sensor.py
+++ b/custom_components/terramow/sensor.py
@@ -849,9 +849,67 @@ async def async_setup_entry(
         
         # 主方向状态传感器
         MainDirectionStatusSensor(basic_data, hass),
+
+        # 电源模式传感器 (dp_107)
+        PowerModeSensor(basic_data, hass),
     ]
     
     async_add_entities(entities)
+
+
+class PowerModeSensor(SensorEntity):
+    """Power mode sensor - uses dp_107 data."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = [
+        "POWER_MODE_RUNNING",
+        "POWER_MODE_STANDBY",
+        "POWER_MODE_HIBERNATE",
+    ]
+    _attr_translation_key = "power_mode"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = basic_data.host
+        self.hass = hass
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model
+        )
+
+    @property
+    def unique_id(self):
+        """Return a unique ID for this entity."""
+        return f"lawn_mower.terramow@{self.host}.power_mode"
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the current power mode."""
+        if not hasattr(self.basic_data, 'lawn_mower') or not self.basic_data.lawn_mower:
+            return None
+
+        power_mode = self.basic_data.lawn_mower.power_mode
+        if power_mode in self._attr_options:
+            return power_mode
+        return None
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.basic_data.lawn_mower is not None
 
 
 class MainDirectionStatusSensor(SensorEntity):

--- a/custom_components/terramow/translations/de.json
+++ b/custom_components/terramow/translations/de.json
@@ -100,6 +100,14 @@
                     "unavailable": "Nicht verfügbar",
                     "no_config": "Keine Konfiguration"
                 }
+            },
+            "power_mode": {
+                "name": "Energiemodus",
+                "state": {
+                    "POWER_MODE_RUNNING": "In Betrieb",
+                    "POWER_MODE_STANDBY": "Bereitschaft",
+                    "POWER_MODE_HIBERNATE": "Ruhezustand"
+                }
             }
         },
         "camera": {
@@ -110,6 +118,12 @@
         "binary_sensor": {
             "charging_state": {
                 "name": "Ladestatus"
+            },
+            "navigation_located": {
+                "name": "Navigation lokalisiert"
+            },
+            "firmware_upgrading": {
+                "name": "Firmware-Aktualisierung"
             }
         },
         "select": {

--- a/custom_components/terramow/translations/en.json
+++ b/custom_components/terramow/translations/en.json
@@ -100,6 +100,14 @@
                     "unavailable": "Unavailable",
                     "no_config": "No Configuration"
                 }
+            },
+            "power_mode": {
+                "name": "Power Mode",
+                "state": {
+                    "POWER_MODE_RUNNING": "Running",
+                    "POWER_MODE_STANDBY": "Standby",
+                    "POWER_MODE_HIBERNATE": "Hibernate"
+                }
             }
         },
         "camera": {
@@ -110,6 +118,12 @@
         "binary_sensor": {
             "charging_state": {
                 "name": "Charging State"
+            },
+            "navigation_located": {
+                "name": "Navigation Located"
+            },
+            "firmware_upgrading": {
+                "name": "Firmware Upgrading"
             }
         },
         "select": {

--- a/custom_components/terramow/translations/zh-Hans.json
+++ b/custom_components/terramow/translations/zh-Hans.json
@@ -100,6 +100,14 @@
                     "unavailable": "不可用",
                     "no_config": "无配置"
                 }
+            },
+            "power_mode": {
+                "name": "电源模式",
+                "state": {
+                    "POWER_MODE_RUNNING": "运行中",
+                    "POWER_MODE_STANDBY": "待机",
+                    "POWER_MODE_HIBERNATE": "休眠"
+                }
             }
         },
         "camera": {
@@ -110,6 +118,12 @@
         "binary_sensor": {
             "charging_state": {
                 "name": "充电状态"
+            },
+            "navigation_located": {
+                "name": "导航定位"
+            },
+            "firmware_upgrading": {
+                "name": "固件升级中"
             }
         },
         "select": {


### PR DESCRIPTION
## Merge order
**Position:** 06 of 13
**Depends on:** #41, #42, #40, #44
**Blocks:** #46
**File conflicts with:** #46

## What this changes
Three diagnostic entities from `dp_107`:
- `binary_sensor.terramow_navigation_located` (icon `mdi:crosshairs-gps`) — based on `is_robot_navi_located`
- `binary_sensor.terramow_firmware_upgrading` (`device_class: update`) — based on `is_upgrading`
- `sensor.terramow_power_mode` (enum: RUNNING / STANDBY / HIBERNATE)

All `EntityCategory.DIAGNOSTIC` — observability, not user controls.

## Data points / protocol references
- `dp_107`, fields `is_robot_navi_located`, `is_upgrading`, `power_mode`

## Validation
- [ ] `python -m compileall custom_components/terramow` clean
- [ ] Tested against firmware <X.Y.Z>
- [ ] Translations updated: en, de, zh-CN, zh-Hans

## Open questions for maintainer
None — all values are documented enums.