### PR TITLE
[07/13] Expose lifetime mowing count and current job type

### DIFF
--- a/custom_components/terramow/sensor.py
+++ b/custom_components/terramow/sensor.py
@@ -177,6 +177,54 @@ class TotalMowingTimeSensor(SensorEntity):
         return statistics_data.get('duration')
 
 
+class TotalMowingJobsSensor(SensorEntity):
+    """Total mowing jobs sensor - uses dp_124 data"""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:counter"
+    _attr_native_unit_of_measurement = None
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "total_mowing_jobs"
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = basic_data.host
+        self.hass = hass
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model
+        )
+
+    @property
+    def unique_id(self):
+        """Return a unique ID for this entity."""
+        return f"lawn_mower.terramow@{self.host}.total_mowing_jobs"
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the state of the sensor."""
+        if not hasattr(self.basic_data, 'lawn_mower') or not self.basic_data.lawn_mower:
+            return None
+
+        statistics_data = self.basic_data.lawn_mower.statistics_data
+        if not statistics_data:
+            return None
+
+        return statistics_data.get('clean_times')
+
+
 class CurrentSessionAreaSensor(SensorEntity):
     """Current session mowing area sensor - uses dp_113 data"""
     
@@ -300,6 +348,65 @@ class CurrentSessionTimeSensor(SensorEntity):
             return None
             
         return current_work_data.get('work_duration')
+
+
+class CurrentJobTypeSensor(SensorEntity):
+    """Current job type sensor - uses dp_113 data"""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:format-list-bulleted-type"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = [
+        "MAP_AREA_TYPE_NONE",
+        "MAP_AREA_TYPE_BUILD_MAP",
+        "MAP_AREA_TYPE_CLEANING",
+        "MAP_AREA_TYPE_BUILD_MAP_AND_CLEANING",
+        "MAP_AREA_TYPE_SELECT_REGION_CLEANING",
+        "MAP_AREA_TYPE_DRAW_REGION_CLEANING",
+        "MAP_AREA_TYPE_EDGE_TRIM_CLEANING",
+    ]
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "current_job_type"
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = basic_data.host
+        self.hass = hass
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model
+        )
+
+    @property
+    def unique_id(self):
+        """Return a unique ID for this entity."""
+        return f"lawn_mower.terramow@{self.host}.current_job_type"
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the state of the sensor."""
+        if not hasattr(self.basic_data, 'lawn_mower') or not self.basic_data.lawn_mower:
+            return None
+
+        current_work_data = self.basic_data.lawn_mower.current_work_data
+        if not current_work_data:
+            return None
+
+        job_type = current_work_data.get('type')
+        if job_type in self._attr_options:
+            return job_type
+        return None
 
 
 class RemainingBladeTimeSensor(SensorEntity):
@@ -834,8 +941,10 @@ async def async_setup_entry(
         
         # 统计和会话传感器
         TotalMowingTimeSensor(basic_data, hass),
+        TotalMowingJobsSensor(basic_data, hass),
         CurrentSessionAreaSensor(basic_data, hass),
         CurrentSessionTimeSensor(basic_data, hass),
+        CurrentJobTypeSensor(basic_data, hass),
         
         # 维护提醒传感器
         RemainingBladeTimeSensor(basic_data, hass),

--- a/custom_components/terramow/translations/de.json
+++ b/custom_components/terramow/translations/de.json
@@ -66,11 +66,26 @@
             "total_mowing_time": {
                 "name": "Gesamte Mähzeit"
             },
+            "total_mowing_jobs": {
+                "name": "Gesamtanzahl Mäheinsätze"
+            },
             "current_session_area": {
                 "name": "Fläche der aktuellen Sitzung"
             },
             "current_session_time": {
                 "name": "Dauer der aktuellen Sitzung"
+            },
+            "current_job_type": {
+                "name": "Aktueller Auftragstyp",
+                "state": {
+                    "MAP_AREA_TYPE_NONE": "Kein",
+                    "MAP_AREA_TYPE_BUILD_MAP": "Karte erstellen",
+                    "MAP_AREA_TYPE_CLEANING": "Mähen",
+                    "MAP_AREA_TYPE_BUILD_MAP_AND_CLEANING": "Karte erstellen und Mähen",
+                    "MAP_AREA_TYPE_SELECT_REGION_CLEANING": "Zone mähen",
+                    "MAP_AREA_TYPE_DRAW_REGION_CLEANING": "Bereich mähen",
+                    "MAP_AREA_TYPE_EDGE_TRIM_CLEANING": "Kantenmähen"
+                }
             },
             "remaining_blade_time": {
                 "name": "Verbleibende Laufzeit der Klingen"

--- a/custom_components/terramow/translations/en.json
+++ b/custom_components/terramow/translations/en.json
@@ -66,11 +66,26 @@
             "total_mowing_time": {
                 "name": "Total Mowing Time"
             },
+            "total_mowing_jobs": {
+                "name": "Total Mowing Jobs"
+            },
             "current_session_area": {
                 "name": "Current Session Area"
             },
             "current_session_time": {
                 "name": "Current Session Time"
+            },
+            "current_job_type": {
+                "name": "Current Job Type",
+                "state": {
+                    "MAP_AREA_TYPE_NONE": "None",
+                    "MAP_AREA_TYPE_BUILD_MAP": "Building Map",
+                    "MAP_AREA_TYPE_CLEANING": "Mowing",
+                    "MAP_AREA_TYPE_BUILD_MAP_AND_CLEANING": "Building Map and Mowing",
+                    "MAP_AREA_TYPE_SELECT_REGION_CLEANING": "Select Region Mowing",
+                    "MAP_AREA_TYPE_DRAW_REGION_CLEANING": "Draw Region Mowing",
+                    "MAP_AREA_TYPE_EDGE_TRIM_CLEANING": "Edge Trim Mowing"
+                }
             },
             "remaining_blade_time": {
                 "name": "Remaining Blade Time"

--- a/custom_components/terramow/translations/zh-Hans.json
+++ b/custom_components/terramow/translations/zh-Hans.json
@@ -66,11 +66,26 @@
             "total_mowing_time": {
                 "name": "总割草时间"
             },
+            "total_mowing_jobs": {
+                "name": "总割草次数"
+            },
             "current_session_area": {
                 "name": "当前会话面积"
             },
             "current_session_time": {
                 "name": "当前会话时间"
+            },
+            "current_job_type": {
+                "name": "当前作业类型",
+                "state": {
+                    "MAP_AREA_TYPE_NONE": "无",
+                    "MAP_AREA_TYPE_BUILD_MAP": "建图",
+                    "MAP_AREA_TYPE_CLEANING": "割草",
+                    "MAP_AREA_TYPE_BUILD_MAP_AND_CLEANING": "建图并割草",
+                    "MAP_AREA_TYPE_SELECT_REGION_CLEANING": "选区割草",
+                    "MAP_AREA_TYPE_DRAW_REGION_CLEANING": "划区割草",
+                    "MAP_AREA_TYPE_EDGE_TRIM_CLEANING": "沿边割草"
+                }
             },
             "remaining_blade_time": {
                 "name": "刀盘剩余时间"


### PR DESCRIPTION
## Merge order
**Position:** 07 of 13
**Depends on:** #41, #42, #40, #44, #45
**Blocks:** none (last `sensor.py`-touching PR in the chain)
**File conflicts with:** none after #45 lands

## What this changes
- `sensor.terramow_total_mowing_jobs` — `state_class: TOTAL_INCREASING` so HA's long-term statistics handle counter resets correctly
- `sensor.terramow_current_job_type` — enum with 7 `MAP_AREA_TYPE_*` values

## Data points / protocol references
- `dp_124.clean_times` (lifetime counter)
- `dp_113.type` (current job type enum, 7 values)

## Validation
- [ ] `python -m compileall custom_components/terramow` clean
- [ ] Tested against firmware <X.Y.Z>
- [ ] Long-term statistics confirmed: counter survives HA restart
- [ ] Translations updated: en, de, zh-CN, zh-Hans

## Open questions for maintainer
None.