### PR TITLE
[08/13] Add edge trim mowing as a button entity

### DIFF
--- a/custom_components/terramow/__init__.py
+++ b/custom_components/terramow/__init__.py
@@ -24,7 +24,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.LAWN_MOWER, Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SELECT, Platform.NUMBER, Platform.CAMERA]
+PLATFORMS: list[Platform] = [Platform.LAWN_MOWER, Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SELECT, Platform.NUMBER, Platform.CAMERA, Platform.BUTTON]
 
 @dataclass
 class TerraMowBasicData:

--- a/custom_components/terramow/button.py
+++ b/custom_components/terramow/button.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import TerraMowBasicData, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up TerraMow button entities."""
+    basic_data = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities([EdgeTrimButton(basic_data)])
+
+
+class EdgeTrimButton(ButtonEntity):
+    """Button that starts the TerraMow in edge-trim mode."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "edge_trim"
+    _attr_icon = "mdi:vector-square"
+
+    def __init__(self, basic_data: TerraMowBasicData) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = basic_data.host
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model,
+        )
+
+    @property
+    def unique_id(self) -> str:
+        return f"lawn_mower.terramow@{self.host}.edge_trim"
+
+    async def async_press(self) -> None:
+        """Trigger edge-trim mowing."""
+        self.basic_data.lawn_mower.start_edge_trim()

--- a/custom_components/terramow/lawn_mower.py
+++ b/custom_components/terramow/lawn_mower.py
@@ -1274,6 +1274,23 @@ class TerraMowLawnMowerEntity(LawnMowerEntity):
         }
         self.publish_data_point(103, command)
 
+    def _start_edge_trim(self):
+        """Start edge-trim mowing"""
+        command = {
+            'seq': self.get_cmd_seq(),
+            'mode': 'START_MODE_EDGE_TRIM_CLEAN'
+        }
+        self.publish_data_point(103, command)
+
+    def start_edge_trim(self):
+        """Public wrapper to start edge-trim mowing."""
+        if not self._can_accept_command():
+            logging.warning("Request too quick, skip start edge trim command")
+            return
+
+        _LOGGER.info("START EDGE TRIM : Sending edge trim command")
+        self._start_edge_trim()
+
     def _resume_mow(self):
         """Resume mowing"""
         command = {'seq': self.get_cmd_seq()}

--- a/custom_components/terramow/strings.json
+++ b/custom_components/terramow/strings.json
@@ -74,6 +74,11 @@
         "name": "Charging State"
       }
     },
+    "button": {
+      "edge_trim": {
+        "name": "Edge Trim"
+      }
+    },
     "select": {
       "region_select": {
         "name": "Region Select"

--- a/custom_components/terramow/translations/de.json
+++ b/custom_components/terramow/translations/de.json
@@ -112,6 +112,11 @@
                 "name": "Ladestatus"
             }
         },
+        "button": {
+            "edge_trim": {
+                "name": "Kantenschnitt"
+            }
+        },
         "select": {
             "region_select": {
                 "name": "Zonenauswahl"

--- a/custom_components/terramow/translations/en.json
+++ b/custom_components/terramow/translations/en.json
@@ -112,6 +112,11 @@
                 "name": "Charging State"
             }
         },
+        "button": {
+            "edge_trim": {
+                "name": "Edge Trim"
+            }
+        },
         "select": {
             "region_select": {
                 "name": "Zone Select"

--- a/custom_components/terramow/translations/zh-Hans.json
+++ b/custom_components/terramow/translations/zh-Hans.json
@@ -112,6 +112,11 @@
                 "name": "充电状态"
             }
         },
+        "button": {
+            "edge_trim": {
+                "name": "沿边修剪"
+            }
+        },
         "select": {
             "region_select": {
                 "name": "分区选择"


### PR DESCRIPTION
## Merge order
**Position:** 08 of 13
**Depends on:** #43 (creates `button.py`)
**Blocks:** none
**File conflicts with:** none after #43 lands

## What this changes
- New `EdgeTrimButton` that publishes a `START_MODE_EDGE_TRIM_CLEAN` command to `dp_103`. Mirrors the existing `_start_normal_mow` pattern in `lawn_mower.py`.
- New helper `start_edge_trim()` on `TerraMowLawnMowerEntity` with the standard `_can_accept_command()` guard.

## Data points / protocol references
- `dp_103` with payload `{seq: <n>, mode: "START_MODE_EDGE_TRIM_CLEAN"}`
- Mode string inferred from the existing `MISSION_EDGE_TRIM_CLEAN` enum naming convention

## Validation
- [ ] `python -m compileall custom_components/terramow` clean
- [ ] Manually pressed button against firmware <X.Y.Z> and verified edge-trim mission starts
- [ ] Translations updated: en, de, zh-CN, zh-Hans

## Open questions for maintainer
- ⚠ Can a maintainer confirm `START_MODE_EDGE_TRIM_CLEAN` is the correct command string? Inferred by convention from the mission enum but not explicitly documented in the `dp_103` spec. If the actual value differs (e.g. `START_MODE_EDGE_TRIM`), please point me at the right enum.