### PR TITLE
[09/13] Implement service to start mowing for selected regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ The following parameters are required:
 - TerraMow firmware version 6.6.0 or later
 - TerraMow APP version 1.6.0 or later
 
+### Services
+
+#### `terramow.start_select_region`
+
+Start mowing for a list of selected sub-regions.
+
+```yaml
+service: terramow.start_select_region
+target:
+  entity_id: lawn_mower.terramow
+data:
+  region_ids: [1, 2]
+```
+
 ### Support
 
 Open an issue on [GitHub](https://github.com/TerraMow/TerraMowHA/issues) for support.

--- a/custom_components/terramow/__init__.py
+++ b/custom_components/terramow/__init__.py
@@ -6,20 +6,36 @@ from dataclasses import dataclass
 import logging
 from typing import Any, Optional
 
+import voluptuous as vol
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     CONF_HOST,
     CONF_PASSWORD,
     Platform,
 )
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, device_registry as dr, entity_registry as er
 
 from .const import (
-    DOMAIN, 
-    CURRENT_HA_VERSION, 
+    DOMAIN,
+    CURRENT_HA_VERSION,
     MIN_REQUIRED_OVERALL_VERSION,
     CompatibilityStatus
+)
+
+SERVICE_START_SELECT_REGION = "start_select_region"
+ATTR_REGION_IDS = "region_ids"
+
+START_SELECT_REGION_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+        vol.Required(ATTR_REGION_IDS): vol.All(
+            cv.ensure_list, [vol.Coerce(int)], vol.Length(min=1)
+        ),
+    }
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -140,7 +156,46 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    _async_register_services(hass)
+
     return True
+
+
+def _async_register_services(hass: HomeAssistant) -> None:
+    """Register integration-level services (idempotent)."""
+    if hass.services.has_service(DOMAIN, SERVICE_START_SELECT_REGION):
+        return
+
+    async def handle_start_select_region(call: ServiceCall) -> None:
+        entity_ids: list[str] = call.data[ATTR_ENTITY_ID]
+        region_ids: list[int] = call.data[ATTR_REGION_IDS]
+
+        registry = er.async_get(hass)
+        domain_data: dict[str, TerraMowBasicData] = hass.data.get(DOMAIN, {})
+
+        targets: list[TerraMowBasicData] = []
+        for entity_id in entity_ids:
+            entry = registry.async_get(entity_id)
+            if entry is None or entry.config_entry_id is None:
+                raise HomeAssistantError(
+                    f"Entity {entity_id} is not a registered TerraMow entity"
+                )
+            basic_data = domain_data.get(entry.config_entry_id)
+            if basic_data is None or basic_data.lawn_mower is None:
+                raise HomeAssistantError(
+                    f"TerraMow lawn mower for {entity_id} is not ready"
+                )
+            targets.append(basic_data)
+
+        for basic_data in targets:
+            basic_data.lawn_mower.start_select_region_clean(region_ids)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_START_SELECT_REGION,
+        handle_start_select_region,
+        schema=START_SELECT_REGION_SCHEMA,
+    )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -152,5 +207,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
         if not hass.data[DOMAIN]:
             hass.data.pop(DOMAIN)
+            if hass.services.has_service(DOMAIN, SERVICE_START_SELECT_REGION):
+                hass.services.async_remove(DOMAIN, SERVICE_START_SELECT_REGION)
 
     return unload_ok

--- a/custom_components/terramow/lawn_mower.py
+++ b/custom_components/terramow/lawn_mower.py
@@ -1274,6 +1274,22 @@ class TerraMowLawnMowerEntity(LawnMowerEntity):
         }
         self.publish_data_point(103, command)
 
+    def start_select_region_clean(self, region_ids: list[int]):
+        """Start mowing for the specified sub-region IDs."""
+        if not region_ids:
+            _LOGGER.warning("start_select_region_clean called with empty region_ids")
+            return
+        if not self._can_accept_command():
+            _LOGGER.warning("Request too quick, skip start_select_region_clean command")
+            return
+        command = {
+            'seq': self.get_cmd_seq(),
+            'mode': 'START_MODE_SELECT_REGION_CLEAN',
+            'select_region': {'region_id': list(region_ids)}
+        }
+        _LOGGER.info("START SELECT REGION CLEAN: regions=%s", region_ids)
+        self.publish_data_point(103, command)
+
     def _resume_mow(self):
         """Resume mowing"""
         command = {'seq': self.get_cmd_seq()}

--- a/custom_components/terramow/services.yaml
+++ b/custom_components/terramow/services.yaml
@@ -1,0 +1,15 @@
+start_select_region:
+  name: Start Select Region Mowing
+  description: Start mowing for the specified sub-region IDs.
+  target:
+    entity:
+      integration: terramow
+      domain: lawn_mower
+  fields:
+    region_ids:
+      name: Region IDs
+      description: List of sub-region IDs to mow.
+      required: true
+      example: "[1, 2]"
+      selector:
+        object:

--- a/custom_components/terramow/strings.json
+++ b/custom_components/terramow/strings.json
@@ -93,5 +93,17 @@
     "unknown": "Unknown",
     "no_regions_available": "No regions available",
     "all_regions": "All regions"
+  },
+  "services": {
+    "start_select_region": {
+      "name": "Start Select Region Mowing",
+      "description": "Start mowing for the specified sub-region IDs.",
+      "fields": {
+        "region_ids": {
+          "name": "Region IDs",
+          "description": "List of sub-region IDs to mow."
+        }
+      }
+    }
   }
 }

--- a/custom_components/terramow/translations/de.json
+++ b/custom_components/terramow/translations/de.json
@@ -178,5 +178,17 @@
         "changing_mode": "Ändere den Modus",
         "active": "Aktiv",
         "pending": "Warte auf Bestätigung"
+    },
+    "services": {
+        "start_select_region": {
+            "name": "Mähen ausgewählter Zonen starten",
+            "description": "Startet das Mähen für die angegebenen Teilbereich-IDs.",
+            "fields": {
+                "region_ids": {
+                    "name": "Zonen-IDs",
+                    "description": "Liste der Teilbereich-IDs, die gemäht werden sollen."
+                }
+            }
+        }
     }
 }

--- a/custom_components/terramow/translations/en.json
+++ b/custom_components/terramow/translations/en.json
@@ -178,5 +178,17 @@
         "changing_mode": "Changing Mode",
         "active": "Active",
         "pending": "Pending Confirmation"
+    },
+    "services": {
+        "start_select_region": {
+            "name": "Start Select Region Mowing",
+            "description": "Start mowing for the specified sub-region IDs.",
+            "fields": {
+                "region_ids": {
+                    "name": "Region IDs",
+                    "description": "List of sub-region IDs to mow."
+                }
+            }
+        }
     }
 }

--- a/custom_components/terramow/translations/zh-Hans.json
+++ b/custom_components/terramow/translations/zh-Hans.json
@@ -178,5 +178,17 @@
         "changing_mode": "正在切换模式",
         "active": "活跃",
         "pending": "等待确认"
+    },
+    "services": {
+        "start_select_region": {
+            "name": "开始选区作业",
+            "description": "对指定的子区域 ID 开始割草作业。",
+            "fields": {
+                "region_ids": {
+                    "name": "区域 ID 列表",
+                    "description": "需要割草的子区域 ID 列表。"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Merge order
**Position:** 09 of 13
**Depends on:** #41, #42
**Blocks:** none
**File conflicts with:** none

## What this changes
- New `services.yaml` registering `terramow.start_select_region` with `region_ids: list[int]` and an `entity_id` target selector.
- New method `start_select_region_clean(region_ids)` on `TerraMowLawnMowerEntity` publishing to `dp_103`.
- README updated with a YAML usage example.

## Data points / protocol references
- `dp_103` with payload:
```json
  {"seq": <n>, "mode": "START_MODE_SELECT_REGION_CLEAN", "select_region": {"region_id": [<ids>]}}
```

## Validation
- [ ] `python -m compileall custom_components/terramow` clean
- [ ] Service called manually against firmware <X.Y.Z> with valid region IDs
- [ ] Translations updated: en, de, zh-CN, zh-Hans (including `services` section in `strings.json`)

## Open questions for maintainer
- ⚠ Confirm the write-side schema. The doc shows `select_region` on the read side but doesn't pin down the write payload. Specifically:
  - Is the inner field `region_id` (singular, with a list value) or `region_ids` (plural)?
  - Is the wrapping object `select_region` or directly inline?

  Listed here so a reviewer with firmware access can verify in one look.