### PR TITLE
[10/13] Add switches for thorough corner cutting and high-grass edge trim

### DIFF
--- a/custom_components/terramow/__init__.py
+++ b/custom_components/terramow/__init__.py
@@ -24,7 +24,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.LAWN_MOWER, Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SELECT, Platform.NUMBER, Platform.CAMERA]
+PLATFORMS: list[Platform] = [Platform.LAWN_MOWER, Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SELECT, Platform.NUMBER, Platform.CAMERA, Platform.SWITCH]
 
 @dataclass
 class TerraMowBasicData:

--- a/custom_components/terramow/select.py
+++ b/custom_components/terramow/select.py
@@ -36,8 +36,9 @@ async def async_setup_entry(
         MowSpeedSelect(basic_data, hass),
         BladeSpeedSelect(basic_data, hass),
         MainDirectionModeSelect(basic_data, hass),
+        HighGrassEdgeTrimModeSelect(basic_data, hass),
     ]
-    
+
     async_add_entities(entities)
 
 class TerraMowZoneSelect(SelectEntity):
@@ -755,5 +756,92 @@ class MainDirectionModeSelect(SelectEntity):
                 elif mode == 'MAIN_DIRECTION_MODE_AUTO_ROTATE':
                     auto_config = main_direction_config.get('auto_rotate_mode_config', {})
                     attrs['auto_rotate_interval'] = auto_config.get('angle_interval', 15)
-        
+
         return attrs
+
+
+class HighGrassEdgeTrimModeSelect(SelectEntity):
+    """High grass edge trim mode selector — published via dp_155.
+
+    Note: high_grass_edge_trim_mode is reported under map_info["mow_param"],
+    but the documented data point for global operation parameter writes is
+    dp_155. Until a dedicated DP for the mow_param fields is documented,
+    we publish the selection to dp_155 with the matching sub-dict — adjust
+    if firmware exposes a different DP.
+    """
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:grass"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_translation_key = "high_grass_edge_trim_mode"
+
+    _attr_options = [
+        "HIGH_GRASS_EDGE_TRIM_STANDARD",
+        "HIGH_GRASS_EDGE_TRIM_INTENSIVE",
+    ]
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = basic_data.host
+        self.hass = hass
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model
+        )
+
+    @property
+    def unique_id(self) -> str:
+        return f"lawn_mower.terramow@{self.host}.high_grass_edge_trim_mode"
+
+    def _get_mow_param(self) -> dict[str, Any] | None:
+        if not hasattr(self.basic_data, 'lawn_mower') or not self.basic_data.lawn_mower:
+            return None
+        map_info = self.basic_data.lawn_mower.map_info
+        if not map_info:
+            return None
+        mow_param = map_info.get('mow_param')
+        if not isinstance(mow_param, dict):
+            return None
+        return mow_param
+
+    @property
+    def current_option(self) -> str | None:
+        mow_param = self._get_mow_param()
+        if mow_param is None:
+            return None
+        trim_cfg = mow_param.get('high_grass_edge_trim_mode')
+        if not isinstance(trim_cfg, dict):
+            return None
+        mode = trim_cfg.get('mode')
+        if mode in self._attr_options:
+            return mode
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        if option not in self._attr_options:
+            _LOGGER.error("Invalid high grass edge trim mode option: %s", option)
+            return
+
+        if not hasattr(self.basic_data, 'lawn_mower') or not self.basic_data.lawn_mower:
+            _LOGGER.error("Lawn mower not available")
+            return
+
+        command = {
+            'high_grass_edge_trim_mode': {
+                'mode': option,
+            }
+        }
+
+        _LOGGER.info("Setting high grass edge trim mode to %s", option)
+        self.basic_data.lawn_mower.publish_data_point(155, command)
+        self.async_write_ha_state()

--- a/custom_components/terramow/strings.json
+++ b/custom_components/terramow/strings.json
@@ -86,6 +86,22 @@
           "MOW_SPEED_TYPE_ADAPTIVE_HIGH": "Adaptive High Speed",
           "MOW_SPEED_TYPE_AUTO": "Auto Speed"
         }
+      },
+      "high_grass_edge_trim_mode": {
+        "name": "High Grass Edge Trim Mode",
+        "state": {
+          "HIGH_GRASS_EDGE_TRIM_STANDARD": "Standard",
+          "HIGH_GRASS_EDGE_TRIM_INTENSIVE": "Intensive"
+        },
+        "options": {
+          "HIGH_GRASS_EDGE_TRIM_STANDARD": "Standard",
+          "HIGH_GRASS_EDGE_TRIM_INTENSIVE": "Intensive"
+        }
+      }
+    },
+    "switch": {
+      "thorough_corner_cutting": {
+        "name": "Thorough Corner Cutting"
       }
     }
   },

--- a/custom_components/terramow/switch.py
+++ b/custom_components/terramow/switch.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+import logging
+from typing import Any
+
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+
+from . import TerraMowBasicData, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up TerraMow switch entities."""
+    basic_data = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities = [
+        ThoroughCornerCuttingSwitch(basic_data, hass),
+    ]
+
+    async_add_entities(entities)
+
+
+class ThoroughCornerCuttingSwitch(SwitchEntity):
+    """Switch for enabling thorough corner cutting in mow_param.
+
+    Note: enable_thorough_corner_cutting is reported under
+    map_info["mow_param"], but the documented data point for global
+    operation parameter writes is dp_155. Until a dedicated DP for the
+    mow_param flags is documented, we publish the toggle to dp_155 with
+    the matching sub-dict — adjust if firmware exposes a different DP.
+    """
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:vector-polyline"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_translation_key = "thorough_corner_cutting"
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = basic_data.host
+        self.hass = hass
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model
+        )
+
+    @property
+    def unique_id(self) -> str:
+        return f"lawn_mower.terramow@{self.host}.thorough_corner_cutting"
+
+    def _get_mow_param(self) -> dict[str, Any] | None:
+        if not hasattr(self.basic_data, 'lawn_mower') or not self.basic_data.lawn_mower:
+            return None
+        map_info = self.basic_data.lawn_mower.map_info
+        if not map_info:
+            return None
+        mow_param = map_info.get('mow_param')
+        if not isinstance(mow_param, dict):
+            return None
+        return mow_param
+
+    @property
+    def is_on(self) -> bool | None:
+        mow_param = self._get_mow_param()
+        if mow_param is None:
+            return None
+        value = mow_param.get('enable_thorough_corner_cutting')
+        if value is None:
+            return None
+        return bool(value)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self._publish(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self._publish(False)
+
+    async def _publish(self, enabled: bool) -> None:
+        if not hasattr(self.basic_data, 'lawn_mower') or not self.basic_data.lawn_mower:
+            _LOGGER.error("Lawn mower not available")
+            return
+
+        command = {'enable_thorough_corner_cutting': enabled}
+        _LOGGER.info("Setting thorough corner cutting to %s", enabled)
+        self.basic_data.lawn_mower.publish_data_point(155, command)

--- a/custom_components/terramow/translations/de.json
+++ b/custom_components/terramow/translations/de.json
@@ -145,6 +145,22 @@
                     "MAIN_DIRECTION_MODE_MULTIPLE": "Doppelt",
                     "MAIN_DIRECTION_MODE_AUTO_ROTATE": "Automatisch drehend"
                 }
+            },
+            "high_grass_edge_trim_mode": {
+                "name": "Kantenmodus bei hohem Gras",
+                "state": {
+                    "HIGH_GRASS_EDGE_TRIM_STANDARD": "Standard",
+                    "HIGH_GRASS_EDGE_TRIM_INTENSIVE": "Intensiv"
+                },
+                "options": {
+                    "HIGH_GRASS_EDGE_TRIM_STANDARD": "Standard",
+                    "HIGH_GRASS_EDGE_TRIM_INTENSIVE": "Intensiv"
+                }
+            }
+        },
+        "switch": {
+            "thorough_corner_cutting": {
+                "name": "Gründliches Eckenmähen"
             }
         },
         "number": {

--- a/custom_components/terramow/translations/en.json
+++ b/custom_components/terramow/translations/en.json
@@ -137,14 +137,30 @@
                 "name": "Main Direction Mode",
                 "state": {
                     "MAIN_DIRECTION_MODE_SINGLE": "Single Direction",
-                    "MAIN_DIRECTION_MODE_MULTIPLE": "Multiple Directions", 
+                    "MAIN_DIRECTION_MODE_MULTIPLE": "Multiple Directions",
                     "MAIN_DIRECTION_MODE_AUTO_ROTATE": "Auto Rotate Direction"
                 },
                 "options": {
                     "MAIN_DIRECTION_MODE_SINGLE": "Single Direction",
-                    "MAIN_DIRECTION_MODE_MULTIPLE": "Multiple Directions", 
+                    "MAIN_DIRECTION_MODE_MULTIPLE": "Multiple Directions",
                     "MAIN_DIRECTION_MODE_AUTO_ROTATE": "Auto Rotate Direction"
                 }
+            },
+            "high_grass_edge_trim_mode": {
+                "name": "High Grass Edge Trim Mode",
+                "state": {
+                    "HIGH_GRASS_EDGE_TRIM_STANDARD": "Standard",
+                    "HIGH_GRASS_EDGE_TRIM_INTENSIVE": "Intensive"
+                },
+                "options": {
+                    "HIGH_GRASS_EDGE_TRIM_STANDARD": "Standard",
+                    "HIGH_GRASS_EDGE_TRIM_INTENSIVE": "Intensive"
+                }
+            }
+        },
+        "switch": {
+            "thorough_corner_cutting": {
+                "name": "Thorough Corner Cutting"
             }
         },
         "number": {

--- a/custom_components/terramow/translations/zh-Hans.json
+++ b/custom_components/terramow/translations/zh-Hans.json
@@ -137,14 +137,30 @@
                 "name": "主方向模式",
                 "state": {
                     "MAIN_DIRECTION_MODE_SINGLE": "单主方向",
-                    "MAIN_DIRECTION_MODE_MULTIPLE": "多主方向", 
+                    "MAIN_DIRECTION_MODE_MULTIPLE": "多主方向",
                     "MAIN_DIRECTION_MODE_AUTO_ROTATE": "自动旋转主方向"
                 },
                 "options": {
                     "MAIN_DIRECTION_MODE_SINGLE": "单主方向",
-                    "MAIN_DIRECTION_MODE_MULTIPLE": "多主方向", 
+                    "MAIN_DIRECTION_MODE_MULTIPLE": "多主方向",
                     "MAIN_DIRECTION_MODE_AUTO_ROTATE": "自动旋转主方向"
                 }
+            },
+            "high_grass_edge_trim_mode": {
+                "name": "高草沿边修剪模式",
+                "state": {
+                    "HIGH_GRASS_EDGE_TRIM_STANDARD": "标准",
+                    "HIGH_GRASS_EDGE_TRIM_INTENSIVE": "强化"
+                },
+                "options": {
+                    "HIGH_GRASS_EDGE_TRIM_STANDARD": "标准",
+                    "HIGH_GRASS_EDGE_TRIM_INTENSIVE": "强化"
+                }
+            }
+        },
+        "switch": {
+            "thorough_corner_cutting": {
+                "name": "彻底贴边切角"
             }
         },
         "number": {


### PR DESCRIPTION
## Merge order
**Position:** 10 of 13
**Depends on:** #41, #42
**Blocks:** none
**File conflicts with:** none

## What this changes
- New `switch.py` platform with `ThoroughCornerCuttingSwitch` writing `enable_thorough_corner_cutting` to `dp_155`.
- New `HighGrassEdgeTrimModeSelect` (in `select.py` or `switch.py`) writing `high_grass_edge_trim_mode.mode` to `dp_155`.
- `__init__.py`: `Platform.SWITCH` added to `PLATFORMS`.

## Data points / protocol references
- `dp_155` (Global Operation Parameter Settings) — assumption based on the `MowingHeightNumber` pattern in `number.py`.
- Exact published payloads:
  - `{"enable_thorough_corner_cutting": <bool>}`
  - `{"high_grass_edge_trim_mode": {"mode": "<enum>"}}`

## Validation
- [ ] `python -m compileall custom_components/terramow` clean
- [ ] Toggled both controls against firmware <X.Y.Z> and verified state round-trips through `map_info`
- [ ] Translations updated: en, de, zh-CN, zh-Hans

## Open questions for maintainer
- ⚠ Confirm `dp_155` is the correct write target for these `mow_param` fields. The fields belong to the `mow_param` block of the `map_info` JSON, but the write path isn't explicitly documented. If a different DP is correct, please point me at it.