### PR TITLE
[11/13] Add options flow and reauth flow for credential changes

### DIFF
--- a/custom_components/terramow/__init__.py
+++ b/custom_components/terramow/__init__.py
@@ -13,11 +13,13 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 
+from .config_flow import CannotConnect, InvalidAuth, validate_input
 from .const import (
-    DOMAIN, 
-    CURRENT_HA_VERSION, 
+    DOMAIN,
+    CURRENT_HA_VERSION,
     MIN_REQUIRED_OVERALL_VERSION,
     CompatibilityStatus
 )
@@ -131,6 +133,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     _LOGGER.info("Setting up TerraMow with host %s", host)
     _LOGGER.debug("TerraMow entry data: %s", dict(entry.data))
+
+    # Verify the broker accepts our credentials before bringing up platforms.
+    # An InvalidAuth error triggers the reauth flow; a connection failure
+    # asks Home Assistant to retry setup later.
+    try:
+        await validate_input(hass, {CONF_HOST: host, CONF_PASSWORD: password})
+    except InvalidAuth as err:
+        raise ConfigEntryAuthFailed("Invalid TerraMow credentials") from err
+    except CannotConnect as err:
+        raise ConfigEntryNotReady(
+            f"Unable to connect to TerraMow at {host}"
+        ) from err
 
     basic_data = TerraMowBasicData(host=host, password=password)
 

--- a/custom_components/terramow/config_flow.py
+++ b/custom_components/terramow/config_flow.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 import logging
+import threading
 from typing import Any
 
 import paho.mqtt.client as mqtt_client
 import voluptuous as vol
 
+from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlow as BaseConfigFlow
 # 移除 ConfigFlowResult 导入
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import MQTT_PORT, MQTT_USERNAME, DOMAIN
@@ -25,31 +27,64 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
+STEP_REAUTH_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
+
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
-    """验证用户输入并测试MQTT连接."""
-    try:
-        def mqtt_connect() -> bool:
-            client = mqtt_client.Client()
-            client.username_pw_set(MQTT_USERNAME, data[CONF_PASSWORD])
+    """验证用户输入并测试MQTT连接.
+
+    Raises InvalidAuth on authentication failure (broker rejects credentials)
+    and CannotConnect for any other failure mode.
+    """
+
+    def mqtt_connect() -> tuple[bool, bool]:
+        """Return (connected, auth_failed) by attempting an MQTT connection."""
+        connected = False
+        auth_failed = False
+        event = threading.Event()
+
+        def on_connect(client, userdata, flags, rc):
+            nonlocal connected, auth_failed
+            # rc 4 = bad username/password, rc 5 = not authorized
+            if rc == 0:
+                connected = True
+            elif rc in (4, 5):
+                auth_failed = True
+            event.set()
+
+        client = mqtt_client.Client()
+        client.username_pw_set(MQTT_USERNAME, data[CONF_PASSWORD])
+        client.on_connect = on_connect
+        try:
+            client.connect(data[CONF_HOST], MQTT_PORT, 5)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error("Connection failed: %s", err)
+            return False, False
+
+        client.loop_start()
+        try:
+            event.wait(timeout=5)
+        finally:
+            client.loop_stop()
             try:
-                client.connect(data[CONF_HOST], MQTT_PORT, 5)
                 client.disconnect()
-                return True
-            except Exception as err:
-                _LOGGER.error("Connection failed: %s", err)
-                return False
+            except Exception:  # noqa: BLE001
+                pass
+        return connected, auth_failed
 
-        # 在executor中运行同步MQTT连接测试
-        is_valid = await hass.async_add_executor_job(mqtt_connect)
+    connected, auth_failed = await hass.async_add_executor_job(mqtt_connect)
 
-        if not is_valid:
-            raise InvalidAuth
+    if auth_failed:
+        raise InvalidAuth
+    if not connected:
+        raise CannotConnect
 
-        return {"title": f"TerraMow ({data[CONF_HOST]})"}
+    return {"title": f"TerraMow ({data[CONF_HOST]})"}
 
-    except Exception as err:
-        _LOGGER.exception("Unexpected error: %s", err)
-        raise CannotConnect from err
 
 class ConfigFlow(BaseConfigFlow, domain=DOMAIN):
     """Handle a config flow for TerraMow."""
@@ -85,6 +120,107 @@ class ConfigFlow(BaseConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors
+        )
+
+    async def async_step_reauth(self, entry_data: dict[str, Any]):
+        """Trigger the re-authentication flow."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ):
+        """Handle re-authentication confirmation."""
+        errors: dict[str, str] = {}
+        entry = self.hass.config_entries.async_get_entry(
+            self.context.get("entry_id")
+        )
+
+        if user_input is not None and entry is not None:
+            updated_data = {
+                **entry.data,
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+            }
+            try:
+                await validate_input(self.hass, updated_data)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                self.hass.config_entries.async_update_entry(
+                    entry, data=updated_data
+                )
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_REAUTH_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> "OptionsFlowHandler":
+        """Return the options flow handler for this entry."""
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle an options flow for TerraMow."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize the options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ):
+        """Manage the TerraMow options (host/password)."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    data={**self.config_entry.data, **user_input},
+                )
+                await self.hass.config_entries.async_reload(
+                    self.config_entry.entry_id
+                )
+                return self.async_create_entry(title="", data={})
+
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_HOST,
+                    default=self.config_entry.data.get(CONF_HOST, ""),
+                ): str,
+                vol.Required(
+                    CONF_PASSWORD,
+                    default=self.config_entry.data.get(CONF_PASSWORD, ""),
+                ): str,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=schema,
+            errors=errors,
         )
 
 

--- a/custom_components/terramow/strings.json
+++ b/custom_components/terramow/strings.json
@@ -7,6 +7,11 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
         }
+      },
+      "reauth_confirm": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        }
       }
     },
     "error": {
@@ -15,7 +20,22 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     }
   },
   "entity": {

--- a/custom_components/terramow/translations/de.json
+++ b/custom_components/terramow/translations/de.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Das Gerät ist bereits konfiguriert"
+            "already_configured": "Das Gerät ist bereits konfiguriert",
+            "reauth_successful": "Erneute Authentifizierung war erfolgreich"
         },
         "error": {
             "cannot_connect": "Verbindung fehlgeschlagen",
@@ -15,7 +16,26 @@
                     "password": "Passwort",
                     "username": "Benutzername"
                 }
+            },
+            "reauth_confirm": {
+                "data": {
+                    "password": "Passwort"
+                }
             }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "host": "Host",
+                    "password": "Passwort"
+                }
+            }
+        },
+        "error": {
+            "cannot_connect": "Verbindung fehlgeschlagen",
+            "invalid_auth": "Ungültige Authentifizierung"
         }
     },
     "entity": {

--- a/custom_components/terramow/translations/en.json
+++ b/custom_components/terramow/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "reauth_successful": "Re-authentication was successful"
         },
         "error": {
             "cannot_connect": "Failed to connect",
@@ -15,7 +16,26 @@
                     "password": "Password",
                     "username": "Username"
                 }
+            },
+            "reauth_confirm": {
+                "data": {
+                    "password": "Password"
+                }
             }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "host": "Host",
+                    "password": "Password"
+                }
+            }
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication"
         }
     },
     "entity": {

--- a/custom_components/terramow/translations/zh-Hans.json
+++ b/custom_components/terramow/translations/zh-Hans.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "设备已配置"
+            "already_configured": "设备已配置",
+            "reauth_successful": "重新认证成功"
         },
         "error": {
             "cannot_connect": "连接失败",
@@ -15,7 +16,26 @@
                     "password": "密码",
                     "username": "用户名"
                 }
+            },
+            "reauth_confirm": {
+                "data": {
+                    "password": "密码"
+                }
             }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "host": "主机",
+                    "password": "密码"
+                }
+            }
+        },
+        "error": {
+            "cannot_connect": "连接失败",
+            "invalid_auth": "认证失败"
         }
     },
     "entity": {


### PR DESCRIPTION
## Merge order
**Position:** 11 of 13
**Depends on:** #41, #42
**Blocks:** #52 (also touches `config_flow.py`)
**File conflicts with:** #52

## What this changes
- `OptionsFlowHandler` allows editing `host` and `password` post-setup via the integration's "Configure" link.
- `async_step_reauth` + `async_step_reauth_confirm` triggered when the initial MQTT connection fails authentication. Triggered via `raise ConfigEntryAuthFailed` in `__init__.py::async_setup_entry`.
- New strings in `strings.json` and the four translation files.

## Data points / protocol references
None — auth flow, not protocol.

## Validation
- [ ] `python -m compileall custom_components/terramow` clean
- [ ] Translations updated: en, de, zh-CN, zh-Hans
- [ ] Wrong password → reauth dialog appears in HA UI
- [ ] Options flow updates host without removing the entry
- [ ] Existing entities survive a host IP change (unique IDs preserved)

## Open questions for maintainer
- The reauth trigger relies on `raise ConfigEntryAuthFailed` from `async_setup_entry` when the initial MQTT auth fails. Worth confirming the failure path actually fires this exception vs. a generic `ConfigEntryNotReady` — ideally a maintainer with a wrong-password setup can verify.