### PR TITLE
[12/13] Add Update entity exposing TerraMow firmware version

### DIFF
--- a/custom_components/terramow/__init__.py
+++ b/custom_components/terramow/__init__.py
@@ -24,7 +24,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.LAWN_MOWER, Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SELECT, Platform.NUMBER, Platform.CAMERA]
+PLATFORMS: list[Platform] = [Platform.LAWN_MOWER, Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SELECT, Platform.NUMBER, Platform.CAMERA, Platform.UPDATE]
 
 @dataclass
 class TerraMowBasicData:

--- a/custom_components/terramow/translations/de.json
+++ b/custom_components/terramow/translations/de.json
@@ -169,6 +169,11 @@
             "multiple_direction_angle2": {
                 "name": "Zweiter Richtungswinkel"
             }
+        },
+        "update": {
+            "firmware": {
+                "name": "Firmware"
+            }
         }
     },
     "state": {

--- a/custom_components/terramow/translations/en.json
+++ b/custom_components/terramow/translations/en.json
@@ -169,6 +169,11 @@
             "multiple_direction_angle2": {
                 "name": "Second Direction Angle"
             }
+        },
+        "update": {
+            "firmware": {
+                "name": "Firmware"
+            }
         }
     },
     "state": {

--- a/custom_components/terramow/translations/zh-Hans.json
+++ b/custom_components/terramow/translations/zh-Hans.json
@@ -169,6 +169,11 @@
             "multiple_direction_angle2": {
                 "name": "第二主方向角度"
             }
+        },
+        "update": {
+            "firmware": {
+                "name": "固件"
+            }
         }
     },
     "state": {

--- a/custom_components/terramow/update.py
+++ b/custom_components/terramow/update.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import TerraMowBasicData, DOMAIN
+from .const import COMPATIBILITY_INFO_DP
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,6 +52,18 @@ class TerraMowFirmwareUpdate(UpdateEntity):
         self.host = self.basic_data.host
         self.hass = hass
         _LOGGER.info("TerraMowFirmwareUpdate entity created")
+
+    async def async_added_to_hass(self) -> None:
+        """Register callback for compatibility info updates once added to HA."""
+        await super().async_added_to_hass()
+        if self.basic_data.lawn_mower:
+            self.basic_data.lawn_mower.register_callback(
+                COMPATIBILITY_INFO_DP, self._on_compatibility_info
+            )
+
+    async def _on_compatibility_info(self, _payload: str) -> None:
+        """Refresh entity state when firmware compatibility info arrives."""
+        self.async_write_ha_state()
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/terramow/update.py
+++ b/custom_components/terramow/update.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.update import (
+    UpdateEntity,
+    UpdateEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import TerraMowBasicData, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the TerraMow update entities."""
+    basic_data = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities = [
+        TerraMowFirmwareUpdate(basic_data, hass),
+    ]
+
+    async_add_entities(entities)
+
+
+class TerraMowFirmwareUpdate(UpdateEntity):
+    """Update entity exposing the TerraMow firmware version."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "firmware"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_supported_features = UpdateEntityFeature(0)
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        """Initialize the firmware update entity."""
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = self.basic_data.host
+        self.hass = hass
+        _LOGGER.info("TerraMowFirmwareUpdate entity created")
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model
+            if self.basic_data.lawn_mower
+            else None,
+        )
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID for this entity."""
+        return f"lawn_mower.terramow@{self.host}.firmware"
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.basic_data.lawn_mower is not None
+
+    def _format_version(self) -> str | None:
+        """Build a version string from the firmware compatibility info."""
+        if not self.basic_data.lawn_mower:
+            return None
+
+        info = self.basic_data.lawn_mower.firmware_version_info
+        if not info:
+            return None
+
+        overall = info.get("overall")
+        if overall is None:
+            return None
+
+        ha_version = info.get("module", {}).get("home_assistant")
+        if ha_version is not None:
+            return f"{overall}.{ha_version}"
+        return str(overall)
+
+    @property
+    def installed_version(self) -> str | None:
+        """Return the currently installed firmware version."""
+        return self._format_version()
+
+    @property
+    def latest_version(self) -> str | None:
+        """Return the latest available firmware version.
+
+        Updates are managed via the TerraMow app, so report the installed
+        version to indicate that no update is available from Home Assistant.
+        """
+        return self._format_version()


### PR DESCRIPTION
## Merge order
**Position:** 12 of 13
**Depends on:** #41 (modern manifest may be needed for the `update` platform)
**Blocks:** none
**File conflicts with:** none

## What this changes
- New `update.py` with `TerraMowFirmwareUpdate(UpdateEntity)`.
- `_attr_entity_category = EntityCategory.DIAGNOSTIC`
- `_attr_supported_features = UpdateEntityFeature(0)` — **no install button by design**: firmware updates run through the TerraMow app, not HA. The entity exposes `installed_version` for visibility, but does not initiate updates.

## Data points / protocol references
- `firmware_version_info` property (already populated from `dp_127` Compatibility Info)

## Validation
- [ ] `python -m compileall custom_components/terramow` clean
- [ ] Entity displays current firmware against firmware <X.Y.Z>
- [ ] Translations updated: en, de, zh-CN, zh-Hans

## Open questions for maintainer
- Is "no install via HA" the right design choice? Alternatives would be (a) deep-link to the TerraMow app, or (b) trigger an OTA via a dedicated DP — but neither is documented as supported. Happy to change if a maintainer confirms an OTA command exists.