### PR TITLE
[13/13] Enable zeroconf/mDNS discovery for TerraMow devices

### DIFF
--- a/custom_components/terramow/config_flow.py
+++ b/custom_components/terramow/config_flow.py
@@ -25,6 +25,12 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
+STEP_USER_PASS_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """验证用户输入并测试MQTT连接."""
     try:
@@ -56,6 +62,10 @@ class ConfigFlow(BaseConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._discovered_host: str | None = None
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ):  # 移除返回值类型注解
@@ -85,6 +95,63 @@ class ConfigFlow(BaseConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors
+        )
+
+    async def async_step_zeroconf(self, discovery_info):
+        """Handle a flow initialized by zeroconf discovery."""
+        host = getattr(discovery_info, "host", None)
+        if host is None and isinstance(discovery_info, dict):
+            host = discovery_info.get("host")
+        if not host:
+            return self.async_abort(reason="cannot_connect")
+
+        _LOGGER.info("Zeroconf discovered TerraMow at %s", host)
+
+        await self.async_set_unique_id(host)
+        self._abort_if_unique_id_configured(updates={CONF_HOST: host})
+
+        self._discovered_host = host
+        self.context["title_placeholders"] = {"host": host}
+
+        return await self.async_step_user_pass()
+
+    async def async_step_user_pass(
+        self, user_input: dict[str, Any] | None = None
+    ):
+        """Ask the user for the password after zeroconf discovery."""
+        errors: dict[str, str] = {}
+
+        if self._discovered_host is None:
+            return await self.async_step_user(user_input)
+
+        if user_input is not None:
+            data = {
+                CONF_HOST: self._discovered_host,
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+            }
+            try:
+                info = await validate_input(self.hass, data)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                _LOGGER.info(
+                    'Setting up discovered host "%s"', self._discovered_host
+                )
+                return self.async_create_entry(
+                    title=info["title"],
+                    data=data,
+                )
+
+        return self.async_show_form(
+            step_id="user_pass",
+            data_schema=STEP_USER_PASS_DATA_SCHEMA,
+            description_placeholders={"host": self._discovered_host},
+            errors=errors,
         )
 
 

--- a/custom_components/terramow/manifest.json
+++ b/custom_components/terramow/manifest.json
@@ -12,5 +12,11 @@
   "iot_class": "local_push",
   "requirements": ["paho-mqtt>=1.6.1", "Pillow>=9.0.0"],
   "version": "0.3.0",
-  "homeassistant": "2023.9.3"
+  "homeassistant": "2023.9.3",
+  "zeroconf": [
+    {
+      "type": "_mqtt._tcp.local.",
+      "name": "terramow*"
+    }
+  ]
 }

--- a/custom_components/terramow/strings.json
+++ b/custom_components/terramow/strings.json
@@ -1,10 +1,18 @@
 {
   "config": {
+    "flow_title": "TerraMow ({host})",
     "step": {
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      },
+      "user_pass": {
+        "title": "TerraMow",
+        "description": "Discovered TerraMow at {host}. Enter the MQTT password to complete setup.",
+        "data": {
           "password": "[%key:common::config_flow::data::password%]"
         }
       }
@@ -15,7 +23,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     }
   },
   "entity": {

--- a/custom_components/terramow/translations/de.json
+++ b/custom_components/terramow/translations/de.json
@@ -1,7 +1,9 @@
 {
     "config": {
+        "flow_title": "TerraMow ({host})",
         "abort": {
-            "already_configured": "Das Gerät ist bereits konfiguriert"
+            "already_configured": "Das Gerät ist bereits konfiguriert",
+            "cannot_connect": "Verbindung fehlgeschlagen"
         },
         "error": {
             "cannot_connect": "Verbindung fehlgeschlagen",
@@ -14,6 +16,13 @@
                     "host": "Host",
                     "password": "Passwort",
                     "username": "Benutzername"
+                }
+            },
+            "user_pass": {
+                "title": "TerraMow",
+                "description": "TerraMow unter {host} gefunden. Bitte das MQTT-Passwort eingeben, um die Einrichtung abzuschließen.",
+                "data": {
+                    "password": "Passwort"
                 }
             }
         }

--- a/custom_components/terramow/translations/en.json
+++ b/custom_components/terramow/translations/en.json
@@ -1,7 +1,9 @@
 {
     "config": {
+        "flow_title": "TerraMow ({host})",
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "cannot_connect": "Failed to connect"
         },
         "error": {
             "cannot_connect": "Failed to connect",
@@ -14,6 +16,13 @@
                     "host": "Host",
                     "password": "Password",
                     "username": "Username"
+                }
+            },
+            "user_pass": {
+                "title": "TerraMow",
+                "description": "Discovered TerraMow at {host}. Enter the MQTT password to complete setup.",
+                "data": {
+                    "password": "Password"
                 }
             }
         }

--- a/custom_components/terramow/translations/zh-Hans.json
+++ b/custom_components/terramow/translations/zh-Hans.json
@@ -1,7 +1,9 @@
 {
     "config": {
+        "flow_title": "TerraMow ({host})",
         "abort": {
-            "already_configured": "设备已配置"
+            "already_configured": "设备已配置",
+            "cannot_connect": "连接失败"
         },
         "error": {
             "cannot_connect": "连接失败",
@@ -14,6 +16,13 @@
                     "host": "主机",
                     "password": "密码",
                     "username": "用户名"
+                }
+            },
+            "user_pass": {
+                "title": "TerraMow",
+                "description": "已发现 TerraMow 设备 ({host})。请输入 MQTT 密码以完成配置。",
+                "data": {
+                    "password": "密码"
                 }
             }
         }


### PR DESCRIPTION
## Merge order
**Position:** 13 of 13
**Depends on:** #41, #50 (rebase on `config_flow.py`)
**Blocks:** none — last PR in the batch
**File conflicts with:** #41 (manifest.json), #50 (config_flow.py)

## What this changes
- `manifest.json`: zeroconf block added.
- `config_flow.py`: `async_step_zeroconf(discovery_info)` pre-fills the host and routes to a new password-only step. Existing `async_step_user` (manual entry) preserved.
- New strings in `strings.json` and the four translation files.

## Data points / protocol references
None — mDNS, not the device's MQTT protocol.

`async_step_zeroconf` consumes:
- `discovery_info.host` → IP / hostname
- `discovery_info.port` → MQTT port
- `discovery_info.properties` → optional metadata for `title_placeholders`

## Validation
- [ ] `python -m compileall custom_components/terramow` clean
- [ ] Manual entry flow still works after the refactor
- [ ] Discovery tested against a real device on the same LAN as firmware <X.Y.Z>
- [ ] Translations updated: en, de, zh-CN, zh-Hans

## Open questions for maintainer
- ⚠ Confirm the mDNS service type. Currently using `_mqtt._tcp.local.` as a pragmatic default. If TerraMow announces a vendor-specific type (e.g. `_terramow._tcp.local.` or similar), please point me at it — that's the one detail no public doc reveals.