### PR TITLE
FIX: Show mowing path live without requiring integration reload (#55)

### DIFF
--- a/custom_components/terramow/lawn_mower.py
+++ b/custom_components/terramow/lawn_mower.py
@@ -951,6 +951,17 @@ class TerraMowLawnMowerEntity(LawnMowerEntity):
         """Handle path meta message and fetch path data via HTTP."""
         seq = self._get_meta_seq(meta, "path")
 
+        # When a new mowing session starts, the device republishes path meta
+        # with seq counted from 0 again. Without this reset, the new meta is
+        # discarded by the seq <= _path_seq guard and the path stays hidden
+        # until the integration is reloaded. Treat a backward seq as a reset.
+        if seq != -1 and self._path_seq != -1 and seq < self._path_seq:
+            _LOGGER.info(
+                "Path seq went backward (%d -> %d); treating as new session",
+                self._path_seq, seq,
+            )
+            self._path_seq = -1
+            self._path_etag = None
         if seq != -1 and seq <= self._path_seq:
             return
         if seq != -1 and seq > self._path_seq:
@@ -997,6 +1008,16 @@ class TerraMowLawnMowerEntity(LawnMowerEntity):
         """Handle history path meta message and fetch history path data via HTTP."""
         seq = self._get_meta_seq(meta, "history path")
 
+        # Same session-reset handling as _async_handle_path_meta: a new mowing
+        # session republishes meta with a seq starting from 0, which would
+        # otherwise be dropped by the seq guard.
+        if seq != -1 and self._history_path_seq != -1 and seq < self._history_path_seq:
+            _LOGGER.info(
+                "History path seq went backward (%d -> %d); treating as new session",
+                self._history_path_seq, seq,
+            )
+            self._history_path_seq = -1
+            self._history_path_etag = None
         if seq != -1 and seq <= self._history_path_seq:
             return
         if seq != -1 and seq > self._history_path_seq:


### PR DESCRIPTION
## Summary

Fixes #55 — the mowing path was missing from the camera image after a new mowing session started, and only reappeared after the user reloaded the TerraMow integration.

## Root cause

When a mowing session starts, the device republishes `path/current/meta` (and `path/history/meta`) with `seq` counted from 0 again. The meta handlers in `lawn_mower.py` guard against stale messages with:

```python
if seq != -1 and seq <= self._path_seq:
    return
```

After a previous session, `_path_seq` is already at some higher value, so the new session's meta (with a lower `seq`) is silently dropped. The HTTP fetch never runs, the path callbacks never fire, and the camera keeps rendering the old/empty path. Reloading the integration re-initialises `_path_seq` to `-1`, which is why the path becomes visible again after a reload.

## Fix

In both `_async_handle_path_meta` and `_async_handle_history_path_meta`, detect a backward `seq` jump and treat it as a new session by clearing the cached `_path_seq` / `_history_path_seq` and the corresponding ETag. The next guard check then accepts the meta normally, the HTTP fetch runs, and the camera callbacks update the rendered path live.

The ETag is also cleared alongside the seq so we can't accidentally short-circuit the new session's fetch with a `304 Not Modified` against a stale validator.

## Test plan

- [ ] Start a mowing session, end it, and start a new one without reloading the integration — confirm the cleaning path renders live as the robot moves.
- [ ] Confirm the history path also continues updating across session boundaries without a reload.
- [ ] Reload the integration mid-session and confirm behaviour is unchanged (path still renders, no duplicate fetches).
- [ ] Check logs for the new `Path seq went backward (... -> ...); treating as new session` info line at the moment a new session starts.