### PR TITLE
NEW: Expose mission, sub-mission and mission_state as ENUM sensors

### DIFF
--- a/custom_components/terramow/sensor.py
+++ b/custom_components/terramow/sensor.py
@@ -30,6 +30,7 @@ from .const import (
     BASE_STATION_MAINTENANCE_CYCLE_MINUTES,
     MOW_SPEED_TYPES,
 )
+from .lawn_mower import Mission, SubMission, MissionState
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -849,8 +850,13 @@ async def async_setup_entry(
         
         # 主方向状态传感器
         MainDirectionStatusSensor(basic_data, hass),
+
+        # 任务状态相关 (dp_107)
+        TerraMowMissionSensor(basic_data, hass),
+        TerraMowSubMissionSensor(basic_data, hass),
+        TerraMowMissionStateSensor(basic_data, hass),
     ]
-    
+
     async_add_entities(entities)
 
 
@@ -958,6 +964,92 @@ class MainDirectionStatusSensor(SensorEntity):
             'MAIN_DIRECTION_MODE_AUTO_ROTATE': 'Auto Rotate'
         }
         attrs['mode_friendly_name'] = mode_names.get(mode, mode)
-        
+
         return attrs
-    
+
+
+class _MissionEnumSensorBase(SensorEntity):
+    """Shared base for the dp_107 mission/sub_mission/state enum sensors."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.ENUM
+
+    _enum_attr: str = ""
+    _unique_suffix: str = ""
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = basic_data.host
+        self.hass = hass
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if self.basic_data.lawn_mower:
+            self.basic_data.lawn_mower.register_callback(107, self._handle_dp_107)
+
+    async def _handle_dp_107(self, _payload: str) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model,
+        )
+
+    @property
+    def unique_id(self) -> str:
+        return f"lawn_mower.terramow@{self.host}.{self._unique_suffix}"
+
+    @property
+    def available(self) -> bool:
+        return self.basic_data.lawn_mower is not None
+
+    @property
+    def native_value(self) -> str | None:
+        if not self.basic_data.lawn_mower:
+            return None
+        member = getattr(self.basic_data.lawn_mower, self._enum_attr, None)
+        if member is None:
+            return None
+        value = member.value if hasattr(member, "value") else str(member)
+        return value if value in self._attr_options else None
+
+
+class TerraMowMissionSensor(_MissionEnumSensorBase):
+    """Current top-level mission (dp_107)."""
+
+    _attr_icon = "mdi:robot-mower-outline"
+    _attr_translation_key = "mission"
+    _attr_options = [member.value for member in Mission]
+    _enum_attr = "mission"
+    _unique_suffix = "mission"
+
+
+class TerraMowSubMissionSensor(_MissionEnumSensorBase):
+    """Current sub-mission (dp_107) — surfaces transient states like waiting for rain."""
+
+    _attr_icon = "mdi:list-status"
+    _attr_translation_key = "sub_mission"
+    _attr_options = [member.value for member in SubMission]
+    _enum_attr = "sub_mission"
+    _unique_suffix = "sub_mission"
+
+
+class TerraMowMissionStateSensor(_MissionEnumSensorBase):
+    """Mission lifecycle state (dp_107): idle / running / paused / abort / complete."""
+
+    _attr_icon = "mdi:state-machine"
+    _attr_translation_key = "mission_state"
+    _attr_options = [member.value for member in MissionState]
+    _enum_attr = "mission_state"
+    _unique_suffix = "mission_state"
+

--- a/custom_components/terramow/strings.json
+++ b/custom_components/terramow/strings.json
@@ -62,6 +62,60 @@
       },
       "pose": {
         "name": "Pose"
+      },
+      "mission": {
+        "name": "Mission",
+        "state": {
+          "MISSION_IDLE": "Idle",
+          "MISSION_RECHARGE": "Recharging",
+          "MISSION_GLOBAL_CLEAN": "Global Mowing",
+          "MISSION_BUILD_MAP": "Building Map",
+          "MISSION_BUILD_MAP_AND_CLEAN": "Building Map and Mowing",
+          "MISSION_TEMPORARY_CLEAN": "Temporary Mowing",
+          "MISSION_BACK_TO_STARTING_POINT": "Returning to Start Point",
+          "MISSION_REMOTE_CONTROL_CLEAN": "Remote Control Mowing",
+          "MISSION_SCHEDULE_GLOBAL_CLEAN": "Scheduled Global Mowing",
+          "MISSION_SCHEDULE_BUILD_MAP_AND_CLEAN": "Scheduled Map Build and Mow",
+          "MISSION_SELECT_REGION_CLEAN": "Region Mowing",
+          "MISSION_CREATE_CUSTOM_PASSAGE": "Creating Custom Passage",
+          "MISSION_BACKUP_MAP": "Backing Up Map",
+          "MISSION_RELOCATE_BASE_STATION": "Relocating Base Station",
+          "MISSION_USER_AUTO_CALIBRATION": "Auto Calibration",
+          "MISSION_RESTORE_BACKUP_MAP": "Restoring Backup Map",
+          "MISSION_SCHEDULE_SELECT_REGION_CLEAN": "Scheduled Region Mowing",
+          "MISSION_DRAW_REGION_CLEAN": "Drawn Region Mowing",
+          "MISSION_EDGE_TRIM_CLEAN": "Edge Trim Mowing",
+          "MISSION_UPDATE_BACKUP_MAP": "Updating Backup Map"
+        }
+      },
+      "sub_mission": {
+        "name": "Sub-mission",
+        "state": {
+          "SUB_MISSION_IDLE": "Idle",
+          "SUB_MISSION_RELOCATION": "Relocating",
+          "SUB_MISSION_RETURN_TO_BASE": "Returning to Base",
+          "SUB_MISSION_OUT_OF_STATION": "Leaving Base Station",
+          "SUB_MISSION_REMOTE_CONTROL": "Remote Control",
+          "SUB_MISSION_SAVING_MAP": "Saving Map",
+          "SUB_MISSION_SETTING_BLADE_HEIGHT": "Adjusting Blade Height",
+          "SUB_MISSION_CHARGING": "Charging",
+          "SUB_MISSION_REMOTE_CONTROL_CLEAN": "Remote Control Mowing",
+          "SUB_MISSION_DEFOGGING": "Defogging",
+          "SUB_MISSION_WAIT_FOR_DAYLIGHT": "Waiting for Daylight",
+          "SUB_MISSION_COOLING_DOWN_MOTOR": "Cooling Down Motor",
+          "SUB_MISSION_WAIT_FOR_RAIN_TO_STOP": "Waiting for Rain to Stop",
+          "SUB_MISSION_FLEXIBLE_STATION_WAIT": "Waiting at Base Station"
+        }
+      },
+      "mission_state": {
+        "name": "Mission State",
+        "state": {
+          "MISSION_STATE_IDLE": "Idle",
+          "MISSION_STATE_RUNNING": "Running",
+          "MISSION_STATE_PAUSE": "Paused",
+          "MISSION_STATE_ABORT": "Aborted",
+          "MISSION_STATE_COMPLETE": "Completed"
+        }
       }
     },
     "camera": {

--- a/custom_components/terramow/translations/de.json
+++ b/custom_components/terramow/translations/de.json
@@ -100,6 +100,60 @@
                     "unavailable": "Nicht verfügbar",
                     "no_config": "Keine Konfiguration"
                 }
+            },
+            "mission": {
+                "name": "Auftrag",
+                "state": {
+                    "MISSION_IDLE": "Bereit",
+                    "MISSION_RECHARGE": "Lädt",
+                    "MISSION_GLOBAL_CLEAN": "Komplettmähen",
+                    "MISSION_BUILD_MAP": "Karte erstellen",
+                    "MISSION_BUILD_MAP_AND_CLEAN": "Karte erstellen und mähen",
+                    "MISSION_TEMPORARY_CLEAN": "Temporäres Mähen",
+                    "MISSION_BACK_TO_STARTING_POINT": "Zurück zum Startpunkt",
+                    "MISSION_REMOTE_CONTROL_CLEAN": "Mähen per Fernsteuerung",
+                    "MISSION_SCHEDULE_GLOBAL_CLEAN": "Geplantes Komplettmähen",
+                    "MISSION_SCHEDULE_BUILD_MAP_AND_CLEAN": "Geplantes Karte erstellen und Mähen",
+                    "MISSION_SELECT_REGION_CLEAN": "Bereichsmähen",
+                    "MISSION_CREATE_CUSTOM_PASSAGE": "Benutzerdefinierte Passage erstellen",
+                    "MISSION_BACKUP_MAP": "Karte sichern",
+                    "MISSION_RELOCATE_BASE_STATION": "Basisstation neu positionieren",
+                    "MISSION_USER_AUTO_CALIBRATION": "Automatische Kalibrierung",
+                    "MISSION_RESTORE_BACKUP_MAP": "Karten-Sicherung wiederherstellen",
+                    "MISSION_SCHEDULE_SELECT_REGION_CLEAN": "Geplantes Bereichsmähen",
+                    "MISSION_DRAW_REGION_CLEAN": "Mähen gezeichneter Zone",
+                    "MISSION_EDGE_TRIM_CLEAN": "Kantentrimmen",
+                    "MISSION_UPDATE_BACKUP_MAP": "Karten-Sicherung aktualisieren"
+                }
+            },
+            "sub_mission": {
+                "name": "Teilauftrag",
+                "state": {
+                    "SUB_MISSION_IDLE": "Bereit",
+                    "SUB_MISSION_RELOCATION": "Lokalisiert",
+                    "SUB_MISSION_RETURN_TO_BASE": "Rückkehr zur Basis",
+                    "SUB_MISSION_OUT_OF_STATION": "Verlässt Basisstation",
+                    "SUB_MISSION_REMOTE_CONTROL": "Fernsteuerung",
+                    "SUB_MISSION_SAVING_MAP": "Karte wird gespeichert",
+                    "SUB_MISSION_SETTING_BLADE_HEIGHT": "Schnitthöhe wird eingestellt",
+                    "SUB_MISSION_CHARGING": "Lädt",
+                    "SUB_MISSION_REMOTE_CONTROL_CLEAN": "Mähen per Fernsteuerung",
+                    "SUB_MISSION_DEFOGGING": "Entfeuchten",
+                    "SUB_MISSION_WAIT_FOR_DAYLIGHT": "Wartet auf Tageslicht",
+                    "SUB_MISSION_COOLING_DOWN_MOTOR": "Motor kühlt ab",
+                    "SUB_MISSION_WAIT_FOR_RAIN_TO_STOP": "Wartet auf Ende des Regens",
+                    "SUB_MISSION_FLEXIBLE_STATION_WAIT": "Wartet an der Basisstation"
+                }
+            },
+            "mission_state": {
+                "name": "Auftragsstatus",
+                "state": {
+                    "MISSION_STATE_IDLE": "Bereit",
+                    "MISSION_STATE_RUNNING": "Läuft",
+                    "MISSION_STATE_PAUSE": "Pausiert",
+                    "MISSION_STATE_ABORT": "Abgebrochen",
+                    "MISSION_STATE_COMPLETE": "Abgeschlossen"
+                }
             }
         },
         "camera": {

--- a/custom_components/terramow/translations/en.json
+++ b/custom_components/terramow/translations/en.json
@@ -100,6 +100,60 @@
                     "unavailable": "Unavailable",
                     "no_config": "No Configuration"
                 }
+            },
+            "mission": {
+                "name": "Mission",
+                "state": {
+                    "MISSION_IDLE": "Idle",
+                    "MISSION_RECHARGE": "Recharging",
+                    "MISSION_GLOBAL_CLEAN": "Global Mowing",
+                    "MISSION_BUILD_MAP": "Building Map",
+                    "MISSION_BUILD_MAP_AND_CLEAN": "Building Map and Mowing",
+                    "MISSION_TEMPORARY_CLEAN": "Temporary Mowing",
+                    "MISSION_BACK_TO_STARTING_POINT": "Returning to Start Point",
+                    "MISSION_REMOTE_CONTROL_CLEAN": "Remote Control Mowing",
+                    "MISSION_SCHEDULE_GLOBAL_CLEAN": "Scheduled Global Mowing",
+                    "MISSION_SCHEDULE_BUILD_MAP_AND_CLEAN": "Scheduled Map Build and Mow",
+                    "MISSION_SELECT_REGION_CLEAN": "Region Mowing",
+                    "MISSION_CREATE_CUSTOM_PASSAGE": "Creating Custom Passage",
+                    "MISSION_BACKUP_MAP": "Backing Up Map",
+                    "MISSION_RELOCATE_BASE_STATION": "Relocating Base Station",
+                    "MISSION_USER_AUTO_CALIBRATION": "Auto Calibration",
+                    "MISSION_RESTORE_BACKUP_MAP": "Restoring Backup Map",
+                    "MISSION_SCHEDULE_SELECT_REGION_CLEAN": "Scheduled Region Mowing",
+                    "MISSION_DRAW_REGION_CLEAN": "Drawn Region Mowing",
+                    "MISSION_EDGE_TRIM_CLEAN": "Edge Trim Mowing",
+                    "MISSION_UPDATE_BACKUP_MAP": "Updating Backup Map"
+                }
+            },
+            "sub_mission": {
+                "name": "Sub-mission",
+                "state": {
+                    "SUB_MISSION_IDLE": "Idle",
+                    "SUB_MISSION_RELOCATION": "Relocating",
+                    "SUB_MISSION_RETURN_TO_BASE": "Returning to Base",
+                    "SUB_MISSION_OUT_OF_STATION": "Leaving Base Station",
+                    "SUB_MISSION_REMOTE_CONTROL": "Remote Control",
+                    "SUB_MISSION_SAVING_MAP": "Saving Map",
+                    "SUB_MISSION_SETTING_BLADE_HEIGHT": "Adjusting Blade Height",
+                    "SUB_MISSION_CHARGING": "Charging",
+                    "SUB_MISSION_REMOTE_CONTROL_CLEAN": "Remote Control Mowing",
+                    "SUB_MISSION_DEFOGGING": "Defogging",
+                    "SUB_MISSION_WAIT_FOR_DAYLIGHT": "Waiting for Daylight",
+                    "SUB_MISSION_COOLING_DOWN_MOTOR": "Cooling Down Motor",
+                    "SUB_MISSION_WAIT_FOR_RAIN_TO_STOP": "Waiting for Rain to Stop",
+                    "SUB_MISSION_FLEXIBLE_STATION_WAIT": "Waiting at Base Station"
+                }
+            },
+            "mission_state": {
+                "name": "Mission State",
+                "state": {
+                    "MISSION_STATE_IDLE": "Idle",
+                    "MISSION_STATE_RUNNING": "Running",
+                    "MISSION_STATE_PAUSE": "Paused",
+                    "MISSION_STATE_ABORT": "Aborted",
+                    "MISSION_STATE_COMPLETE": "Completed"
+                }
             }
         },
         "camera": {

--- a/custom_components/terramow/translations/zh-Hans.json
+++ b/custom_components/terramow/translations/zh-Hans.json
@@ -100,6 +100,60 @@
                     "unavailable": "不可用",
                     "no_config": "无配置"
                 }
+            },
+            "mission": {
+                "name": "任务",
+                "state": {
+                    "MISSION_IDLE": "空闲",
+                    "MISSION_RECHARGE": "回充",
+                    "MISSION_GLOBAL_CLEAN": "全局割草",
+                    "MISSION_BUILD_MAP": "建图",
+                    "MISSION_BUILD_MAP_AND_CLEAN": "建图并割草",
+                    "MISSION_TEMPORARY_CLEAN": "临时割草",
+                    "MISSION_BACK_TO_STARTING_POINT": "返回起点",
+                    "MISSION_REMOTE_CONTROL_CLEAN": "遥控割草",
+                    "MISSION_SCHEDULE_GLOBAL_CLEAN": "预约全局割草",
+                    "MISSION_SCHEDULE_BUILD_MAP_AND_CLEAN": "预约建图并割草",
+                    "MISSION_SELECT_REGION_CLEAN": "选区割草",
+                    "MISSION_CREATE_CUSTOM_PASSAGE": "创建自定义通道",
+                    "MISSION_BACKUP_MAP": "备份地图",
+                    "MISSION_RELOCATE_BASE_STATION": "重新定位基站",
+                    "MISSION_USER_AUTO_CALIBRATION": "自动校准",
+                    "MISSION_RESTORE_BACKUP_MAP": "恢复备份地图",
+                    "MISSION_SCHEDULE_SELECT_REGION_CLEAN": "预约选区割草",
+                    "MISSION_DRAW_REGION_CLEAN": "划区割草",
+                    "MISSION_EDGE_TRIM_CLEAN": "沿边修剪",
+                    "MISSION_UPDATE_BACKUP_MAP": "更新备份地图"
+                }
+            },
+            "sub_mission": {
+                "name": "子任务",
+                "state": {
+                    "SUB_MISSION_IDLE": "空闲",
+                    "SUB_MISSION_RELOCATION": "重定位中",
+                    "SUB_MISSION_RETURN_TO_BASE": "返回基站",
+                    "SUB_MISSION_OUT_OF_STATION": "离开基站",
+                    "SUB_MISSION_REMOTE_CONTROL": "遥控",
+                    "SUB_MISSION_SAVING_MAP": "保存地图",
+                    "SUB_MISSION_SETTING_BLADE_HEIGHT": "调整刀盘高度",
+                    "SUB_MISSION_CHARGING": "充电中",
+                    "SUB_MISSION_REMOTE_CONTROL_CLEAN": "遥控割草",
+                    "SUB_MISSION_DEFOGGING": "除雾",
+                    "SUB_MISSION_WAIT_FOR_DAYLIGHT": "等待天亮",
+                    "SUB_MISSION_COOLING_DOWN_MOTOR": "电机降温中",
+                    "SUB_MISSION_WAIT_FOR_RAIN_TO_STOP": "等待雨停",
+                    "SUB_MISSION_FLEXIBLE_STATION_WAIT": "在基站等待"
+                }
+            },
+            "mission_state": {
+                "name": "任务状态",
+                "state": {
+                    "MISSION_STATE_IDLE": "空闲",
+                    "MISSION_STATE_RUNNING": "运行中",
+                    "MISSION_STATE_PAUSE": "已暂停",
+                    "MISSION_STATE_ABORT": "已中止",
+                    "MISSION_STATE_COMPLETE": "已完成"
+                }
             }
         },
         "camera": {


### PR DESCRIPTION
Closes #58.

> Re-opened from a fresh branch off `TerraMow:main`. The previous PR (#62) was based on my fork's `main`, which had several other unmerged PRs already integrated, so the diff was much larger than just this feature.

## What this changes
Adds three diagnostic ENUM sensors derived from `dp_107` fields the integration already tracks but only collapses into `LawnMowerActivity`:

- `sensor.terramow_mission` — `Mission` enum (e.g. `MISSION_GLOBAL_CLEAN`, `MISSION_RECHARGE`, `MISSION_EDGE_TRIM_CLEAN`)
- `sensor.terramow_sub_mission` — `SubMission` enum (e.g. `SUB_MISSION_WAIT_FOR_RAIN_TO_STOP`, `SUB_MISSION_COOLING_DOWN_MOTOR`, `SUB_MISSION_FLEXIBLE_STATION_WAIT`)
- `sensor.terramow_mission_state` — `MissionState` lifecycle (`idle` / `running` / `paused` / `abort` / `complete`)

Each sensor declares `_attr_device_class = SensorDeviceClass.ENUM` with `_attr_options` populated from the enum, and lives under `EntityCategory.DIAGNOSTIC`.

## Implementation notes
A small `_MissionEnumSensorBase` factor-out holds the shared boilerplate. Each sensor registers a `dp_107` callback in `async_added_to_hass` and calls `async_write_ha_state()` on every payload, so state pushes through immediately rather than waiting for the 30-second default poll. The lawn-mower's existing `on_mission_status` parser is registered first via `register_all_callbacks`, so by the time the refresh fires the underlying enum attributes are populated.

## Translations
`name` plus every state value translated for `en`, `de`, `zh-Hans` and added to canonical `strings.json`.

## Validation
- [x] `python -m ast` clean on `sensor.py`
- [x] `json.load` clean on `strings.json` and all three locale files
- [ ] Verify on real device that all three sensors populate after dp_107 arrives

## Why this is useful
Concrete automations that aren't possible today without these:
- Notify when the mower is waiting for rain to stop
- Different lighting / sound when the mower is in flexible-station-wait vs actively docked
- Alert on motor cool-down events
- Distinguish a paused-by-user from a paused-by-fault state for dashboards