### PR TITLE
NEW: Promote dp_117 map flags to binary sensors

### DIFF
--- a/custom_components/terramow/binary_sensor.py
+++ b/custom_components/terramow/binary_sensor.py
@@ -27,6 +27,9 @@ async def async_setup_entry(
 
     entities = [
         TerraMowChargingSensor(basic_data, hass),
+        TerraMowMapDetectedBinarySensor(basic_data, hass),
+        TerraMowMapBuildableBinarySensor(basic_data, hass),
+        TerraMowMapBackingUpBinarySensor(basic_data, hass),
     ]
 
     async_add_entities(entities)
@@ -83,3 +86,85 @@ class TerraMowChargingSensor(BinarySensorEntity):
     def available(self):
         """Return True if entity is available."""
         return self.basic_data.lawn_mower is not None
+
+
+class _MapStatusBinarySensorBase(BinarySensorEntity):
+    """Shared base for dp_117 map_status flag binary sensors."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    _map_status_field: str = ""
+    _unique_suffix: str = ""
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = self.basic_data.host
+        self.hass = hass
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if self.basic_data.lawn_mower:
+            self.basic_data.lawn_mower.register_callback(117, self._handle_dp_117)
+
+    async def _handle_dp_117(self, _payload: str) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model,
+        )
+
+    @property
+    def unique_id(self) -> str:
+        return f"lawn_mower.terramow@{self.host}.{self._unique_suffix}"
+
+    @property
+    def available(self) -> bool:
+        return self.basic_data.lawn_mower is not None
+
+    @property
+    def is_on(self) -> bool | None:
+        if not self.basic_data.lawn_mower:
+            return None
+        map_status = self.basic_data.lawn_mower.map_status
+        if not map_status:
+            return None
+        value = map_status.get(self._map_status_field)
+        return bool(value) if value is not None else None
+
+
+class TerraMowMapDetectedBinarySensor(_MapStatusBinarySensorBase):
+    """True when the device reports an active/detected map."""
+
+    _attr_translation_key = "map_detected"
+    _attr_icon = "mdi:map-check"
+    _map_status_field = "is_map_detected"
+    _unique_suffix = "map_detected"
+
+
+class TerraMowMapBuildableBinarySensor(_MapStatusBinarySensorBase):
+    """True when the device is in a state where a build-map command would be accepted."""
+
+    _attr_translation_key = "map_buildable"
+    _attr_icon = "mdi:map-plus"
+    _map_status_field = "is_able_to_run_build_map"
+    _unique_suffix = "map_buildable"
+
+
+class TerraMowMapBackingUpBinarySensor(_MapStatusBinarySensorBase):
+    """True while a map backup is in progress."""
+
+    _attr_translation_key = "map_backing_up"
+    _attr_icon = "mdi:cloud-upload-outline"
+    _map_status_field = "is_backing_up_map"
+    _unique_suffix = "map_backing_up"

--- a/custom_components/terramow/strings.json
+++ b/custom_components/terramow/strings.json
@@ -72,6 +72,15 @@
     "binary_sensor": {
       "charging_state": {
         "name": "Charging State"
+      },
+      "map_detected": {
+        "name": "Map Detected"
+      },
+      "map_buildable": {
+        "name": "Map Buildable"
+      },
+      "map_backing_up": {
+        "name": "Map Backing Up"
       }
     },
     "select": {

--- a/custom_components/terramow/translations/de.json
+++ b/custom_components/terramow/translations/de.json
@@ -110,6 +110,15 @@
         "binary_sensor": {
             "charging_state": {
                 "name": "Ladestatus"
+            },
+            "map_detected": {
+                "name": "Karte erkannt"
+            },
+            "map_buildable": {
+                "name": "Karte kann erstellt werden"
+            },
+            "map_backing_up": {
+                "name": "Karte wird gesichert"
             }
         },
         "select": {

--- a/custom_components/terramow/translations/en.json
+++ b/custom_components/terramow/translations/en.json
@@ -110,6 +110,15 @@
         "binary_sensor": {
             "charging_state": {
                 "name": "Charging State"
+            },
+            "map_detected": {
+                "name": "Map Detected"
+            },
+            "map_buildable": {
+                "name": "Map Buildable"
+            },
+            "map_backing_up": {
+                "name": "Map Backing Up"
             }
         },
         "select": {

--- a/custom_components/terramow/translations/zh-Hans.json
+++ b/custom_components/terramow/translations/zh-Hans.json
@@ -110,6 +110,15 @@
         "binary_sensor": {
             "charging_state": {
                 "name": "充电状态"
+            },
+            "map_detected": {
+                "name": "已识别地图"
+            },
+            "map_buildable": {
+                "name": "可建图"
+            },
+            "map_backing_up": {
+                "name": "正在备份地图"
             }
         },
         "select": {


### PR DESCRIPTION
Closes #59.

> Re-opened from a fresh branch off `TerraMow:main`. The previous PR (#63) was based on my fork's `main`, which had several other unmerged PRs already integrated, so the diff was much larger than just this feature.

## What this changes
Promotes three flags from `dp_117` (currently only available as `extra_state_attributes` on the Map Status sensor in some downstream entity sets) into first-class binary sensors so they can be used as automation triggers and dashboard indicators without templates:

- `binary_sensor.terramow_map_detected` ← `map_status.is_map_detected`
- `binary_sensor.terramow_map_buildable` ← `map_status.is_able_to_run_build_map`
- `binary_sensor.terramow_map_backing_up` ← `map_status.is_backing_up_map`

## Implementation notes
A small `_MapStatusBinarySensorBase` factor-out holds the shared boilerplate. Each binary sensor registers a `dp_117` callback in `async_added_to_hass` and calls `async_write_ha_state()` on every payload, so state pushes through immediately rather than lagging up to 30 seconds behind the device.

## Translations
Names added to canonical `strings.json` and to `translations/{en,de,zh-Hans}.json`.

## Validation
- [x] `python -m ast` clean on `binary_sensor.py`
- [x] `json.load` clean on `strings.json` and all three locale files
- [ ] Verify on real device that the three sensors track the underlying flags correctly

## Why this is useful
- "Map detected" trivially gates other automations ("only run schedule if a map is loaded")
- "Map buildable" lets a dashboard surface a build-map call-to-action only when the device is in a state to accept it
- "Map backing up" gives users a visible, automatable signal during a process that otherwise looks like a stall