### PR TITLE
NEW: Add current-session mowing progress (%) sensor

### DIFF
--- a/custom_components/terramow/sensor.py
+++ b/custom_components/terramow/sensor.py
@@ -249,8 +249,70 @@ class CurrentSessionAreaSensor(SensorEntity):
         is_completed = current_work_data.get('is_completed')
         if is_completed is not None:
             attrs['is_completed'] = is_completed
-            
+
         return attrs
+
+
+class CurrentSessionProgressSensor(SensorEntity):
+    """Progress (%) of the current session, derived from dp_113 clean_area/total_area."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:progress-check"
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "current_session_progress"
+
+    def __init__(
+        self,
+        basic_data: TerraMowBasicData,
+        hass: HomeAssistant,
+    ) -> None:
+        super().__init__()
+        self.basic_data = basic_data
+        self.host = basic_data.host
+        self.hass = hass
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if self.basic_data.lawn_mower:
+            self.basic_data.lawn_mower.register_callback(113, self._handle_dp_113)
+
+    async def _handle_dp_113(self, _payload: str) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={('TerraMowLawnMower', self.basic_data.host)},
+            name='TerraMow',
+            manufacturer='TerraMow',
+            model=self.basic_data.lawn_mower.device_model,
+        )
+
+    @property
+    def unique_id(self) -> str:
+        return f"lawn_mower.terramow@{self.host}.current_session_progress"
+
+    @property
+    def available(self) -> bool:
+        return self.basic_data.lawn_mower is not None
+
+    @property
+    def native_value(self) -> float | None:
+        if not self.basic_data.lawn_mower:
+            return None
+        current_work_data = self.basic_data.lawn_mower.current_work_data
+        if not current_work_data:
+            return None
+        total_area = current_work_data.get('total_area') or 0
+        clean_area = current_work_data.get('clean_area') or 0
+        if total_area <= 0:
+            return None
+        progress = 100.0 * clean_area / total_area
+        # Cap at 100; the device occasionally reports clean_area > total_area
+        # near the very end of a session.
+        return round(min(progress, 100.0), 1)
 
 
 class CurrentSessionTimeSensor(SensorEntity):
@@ -835,6 +897,7 @@ async def async_setup_entry(
         # 统计和会话传感器
         TotalMowingTimeSensor(basic_data, hass),
         CurrentSessionAreaSensor(basic_data, hass),
+        CurrentSessionProgressSensor(basic_data, hass),
         CurrentSessionTimeSensor(basic_data, hass),
         
         # 维护提醒传感器

--- a/custom_components/terramow/strings.json
+++ b/custom_components/terramow/strings.json
@@ -62,6 +62,9 @@
       },
       "pose": {
         "name": "Pose"
+      },
+      "current_session_progress": {
+        "name": "Current Session Progress"
       }
     },
     "camera": {

--- a/custom_components/terramow/translations/de.json
+++ b/custom_components/terramow/translations/de.json
@@ -69,6 +69,9 @@
             "current_session_area": {
                 "name": "Fläche der aktuellen Sitzung"
             },
+            "current_session_progress": {
+                "name": "Fortschritt der aktuellen Sitzung"
+            },
             "current_session_time": {
                 "name": "Dauer der aktuellen Sitzung"
             },

--- a/custom_components/terramow/translations/en.json
+++ b/custom_components/terramow/translations/en.json
@@ -69,6 +69,9 @@
             "current_session_area": {
                 "name": "Current Session Area"
             },
+            "current_session_progress": {
+                "name": "Current Session Progress"
+            },
             "current_session_time": {
                 "name": "Current Session Time"
             },

--- a/custom_components/terramow/translations/zh-Hans.json
+++ b/custom_components/terramow/translations/zh-Hans.json
@@ -69,6 +69,9 @@
             "current_session_area": {
                 "name": "当前会话面积"
             },
+            "current_session_progress": {
+                "name": "当前会话进度"
+            },
             "current_session_time": {
                 "name": "当前会话时间"
             },


### PR DESCRIPTION
Closes #60.

> Re-opened from a fresh branch off `TerraMow:main`. The previous PR (#64) was based on my fork's `main`, which had several other unmerged PRs already integrated, so the diff was much larger than just this feature.

## What this changes
Derives a new sensor from `dp_113` (current work data) that the integration already receives:

- `sensor.terramow_current_session_progress` = `round(100 * clean_area / total_area, 1)`, capped at 100, returns `None` when `total_area` is 0/missing
- `unit_of_measurement = "%"`, `state_class = MEASUREMENT`, `EntityCategory.DIAGNOSTIC`

The existing `current_session_area` sensor is unchanged.

## Implementation notes
- Returns `None` (HA shows "unknown") between sessions instead of a misleading 0%
- Cap at 100 because the device occasionally reports `clean_area > total_area` near the very end of a session
- Push refresh on `dp_113` callback registered in `async_added_to_hass`, so the percentage stays in step with the existing `current_session_area` sensor instead of waiting for the 30s default poll

## Translations
Name added to canonical `strings.json` and to `translations/{en,de,zh-Hans}.json`.

## Validation
- [x] `python -m ast` clean on `sensor.py`
- [x] `json.load` clean on `strings.json` and all three locale files
- [ ] Verify on real device during an active session that progress climbs and resets between sessions

## Why this is useful
- Progress bars on dashboards (HA's `gauge` / `bar-card` cards both like a 0–100 % sensor)
- Notifications at thresholds ("notify when the current session is past 90 %")
- Better at-a-glance status than the two raw area numbers