### PR TITLE
Add reconfigure flow so the host/IP can be changed without re-adding

### DIFF
--- a/custom_components/terramow/config_flow.py
+++ b/custom_components/terramow/config_flow.py
@@ -87,6 +87,38 @@ class ConfigFlow(BaseConfigFlow, domain=DOMAIN):
             errors=errors
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ):  # 移除返回值类型注解
+        """Handle reconfiguration of an existing entry (e.g. a changed IP/host)."""
+        errors: dict[str, str] = {}
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                _LOGGER.info('Reconfiguring host to "%s"', user_input[CONF_HOST])
+                self.hass.config_entries.async_update_entry(
+                    entry, title=info["title"], data=user_input
+                )
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_abort(reason="reconfigure_successful")
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA, entry.data if entry else {}
+            ),
+            errors=errors,
+        )
+
 
 class CannotConnect(HomeAssistantError):
     """Error to indicate we cannot connect."""

--- a/custom_components/terramow/strings.json
+++ b/custom_components/terramow/strings.json
@@ -7,6 +7,14 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
         }
+      },
+      "reconfigure": {
+        "title": "Reconfigure TerraMow",
+        "description": "Update the IP address / hostname or password of your TerraMow.",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
       }
     },
     "error": {
@@ -15,7 +23,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   },
   "entity": {

--- a/custom_components/terramow/translations/de.json
+++ b/custom_components/terramow/translations/de.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Das Gerät ist bereits konfiguriert"
+            "already_configured": "Das Gerät ist bereits konfiguriert",
+            "reconfigure_successful": "Die Neukonfiguration war erfolgreich"
         },
         "error": {
             "cannot_connect": "Verbindung fehlgeschlagen",
@@ -14,6 +15,14 @@
                     "host": "Host",
                     "password": "Passwort",
                     "username": "Benutzername"
+                }
+            },
+            "reconfigure": {
+                "title": "TerraMow neu konfigurieren",
+                "description": "IP-Adresse / Hostname oder Passwort deiner TerraMow aktualisieren.",
+                "data": {
+                    "host": "Host",
+                    "password": "Passwort"
                 }
             }
         }

--- a/custom_components/terramow/translations/en.json
+++ b/custom_components/terramow/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "reconfigure_successful": "Re-configuration was successful"
         },
         "error": {
             "cannot_connect": "Failed to connect",
@@ -14,6 +15,14 @@
                     "host": "Host",
                     "password": "Password",
                     "username": "Username"
+                }
+            },
+            "reconfigure": {
+                "title": "Reconfigure TerraMow",
+                "description": "Update the IP address / hostname or password of your TerraMow.",
+                "data": {
+                    "host": "Host",
+                    "password": "Password"
                 }
             }
         }


### PR DESCRIPTION
## Problem
The mower's address is stored once at setup and there is no way to change it afterwards (no reconfigure or options flow). When the mower gets a new IP via DHCP, the only remedy is to delete and re-add the integration, losing its settings.

## Changes
- Add `async_step_reconfigure` so the host/hostname and password can be updated in place from the UI; the entry is then reloaded.
- Add the `reconfigure` step + `reconfigure_successful` strings, with `en` and `de` translations.

Uses only long-stable config-entry helpers (`async_get_entry`, `async_update_entry`, `async_reload`, `add_suggested_values_to_schema`), so it does not raise the minimum HA version.

Tip for affected users: pointing the integration at a stable hostname or a DHCP-reserved address avoids the problem entirely.
